### PR TITLE
feat(claude-native): support native claude CLI plugin installation

### DIFF
--- a/examples/workspaces/claude-native/.allagents/workspace.yaml
+++ b/examples/workspaces/claude-native/.allagents/workspace.yaml
@@ -1,0 +1,34 @@
+# Example: Claude-native plugin installation
+#
+# This example demonstrates using the `claude-native` client type,
+# which installs plugins using the `claude` CLI instead of copying
+# files to `.claude/` directories.
+#
+# Prerequisites:
+# - Claude CLI must be installed (`claude --version`)
+# - Marketplaces are auto-registered on first sync
+#
+# How it works:
+# - `claude-native` uses `claude plugin marketplace add` to register marketplaces
+# - Then uses `claude plugin install <plugin>@<marketplace> --scope project`
+# - This is different from the `claude` client which copies files directly
+#
+# Benefits:
+# - Plugins are managed by the official Claude CLI
+# - Plugin updates, enable/disable via `claude plugin` commands
+# - Native integration with Claude's plugin system
+#
+# Usage:
+#   allagents workspace sync
+
+repositories: []
+
+plugins:
+  # Marketplace-based plugins work with claude-native
+  # The marketplace is auto-registered, then the plugin is installed via CLI
+  - source: superpowers@obra/superpowers-marketplace
+    clients:
+      - claude-native
+
+clients:
+  - claude-native

--- a/examples/workspaces/claude-native/.claude/settings.json
+++ b/examples/workspaces/claude-native/.claude/settings.json
@@ -1,0 +1,3 @@
+{
+  "enabledPlugins": {}
+}

--- a/src/cli/commands/plugin.ts
+++ b/src/cli/commands/plugin.ts
@@ -37,7 +37,7 @@ import {
   pluginUpdateMeta,
 } from '../metadata/plugin.js';
 import { skillsCmd } from './plugin-skills.js';
-import { formatMcpResult, buildSyncData } from '../format-sync.js';
+import { formatMcpResult, formatNativeResult, buildSyncData } from '../format-sync.js';
 import { getPluginSource, type PluginEntry } from '../../models/workspace-config.js';
 
 
@@ -88,6 +88,17 @@ async function runSyncAndPrint(options?: { skipAgentFiles?: boolean }): Promise<
           console.log(
             `    - ${failedResult.destination}: ${failedResult.error}`,
           );
+        }
+      }
+    }
+
+    // Print native plugin sync results
+    if (result.nativeResult) {
+      const nativeLines = formatNativeResult(result.nativeResult);
+      if (nativeLines.length > 0) {
+        console.log('\nclaude-native:');
+        for (const line of nativeLines) {
+          console.log(line);
         }
       }
     }
@@ -165,6 +176,18 @@ async function runUserSyncAndPrint(): Promise<{ ok: boolean; syncData: ReturnTyp
       if (mcpLines.length > 0) {
         console.log('');
         for (const line of mcpLines) {
+          console.log(line);
+        }
+      }
+    }
+
+    // Print native plugin sync results
+    if (result.nativeResult) {
+      const nativeLines = formatNativeResult(result.nativeResult);
+      if (nativeLines.length > 0) {
+        console.log('');
+        console.log('claude-native:');
+        for (const line of nativeLines) {
           console.log(line);
         }
       }

--- a/src/cli/commands/plugin.ts
+++ b/src/cli/commands/plugin.ts
@@ -570,6 +570,7 @@ const pluginListCmd = command({
           version: string | null;
           scope: string | null;
           enabled: boolean;
+          native: boolean;
         }> = [];
         const allWarnings: string[] = [];
         for (const mp of toList) {
@@ -584,6 +585,7 @@ const pluginListCmd = command({
               version,
               scope: installed?.scope ?? null,
               enabled: !!installed,
+              native: installed?.clients?.includes('claude-native') ?? false,
             });
           }
           for (const warning of result.warnings) {
@@ -660,7 +662,8 @@ const pluginListCmd = command({
         for (const entry of installedPlugins) {
           console.log(`  ❯ ${entry.name}@${entry.marketplace}`);
           console.log(`    Version: ${entry.version ?? 'unknown'}`);
-          console.log(`    Scope: ${entry.installed?.scope}\n`);
+          const viaLabel = entry.installed?.clients?.includes('claude-native') ? ' (via: claude-cli)' : '';
+          console.log(`    Scope: ${entry.installed?.scope}${viaLabel}\n`);
         }
       }
 

--- a/src/cli/commands/workspace.ts
+++ b/src/cli/commands/workspace.ts
@@ -13,7 +13,7 @@ import { buildDescription, conciseSubcommands } from '../help.js';
 import { initMeta, syncMeta, statusMeta, pruneMeta } from '../metadata/workspace.js';
 import { ClientTypeSchema } from '../../models/workspace-config.js';
 import { repoAddMeta, repoRemoveMeta, repoListMeta } from '../metadata/workspace-repo.js';
-import { formatMcpResult, buildSyncData } from '../format-sync.js';
+import { formatMcpResult, formatNativeResult, buildSyncData } from '../format-sync.js';
 
 
 // =============================================================================
@@ -216,6 +216,18 @@ const syncCmd = command({
         if (mcpLines.length > 0) {
           console.log('');
           for (const line of mcpLines) {
+            console.log(line);
+          }
+        }
+      }
+
+      // Print native plugin sync results
+      if (result.nativeResult) {
+        const nativeLines = formatNativeResult(result.nativeResult);
+        if (nativeLines.length > 0) {
+          console.log('');
+          console.log('claude-native:');
+          for (const line of nativeLines) {
             console.log(line);
           }
         }

--- a/src/cli/format-sync.ts
+++ b/src/cli/format-sync.ts
@@ -1,5 +1,6 @@
 import type { SyncResult } from '../core/sync.js';
 import type { McpMergeResult } from '../core/vscode-mcp.js';
+import type { NativeSyncResult } from '../core/claude-native.js';
 
 /**
  * Format MCP server sync results as display lines.
@@ -36,6 +37,31 @@ export function formatMcpResult(mcpResult: McpMergeResult): string[] {
 }
 
 /**
+ * Format native CLI plugin sync results as display lines.
+ */
+export function formatNativeResult(nativeResult: NativeSyncResult): string[] {
+  const lines: string[] = [];
+
+  if (nativeResult.marketplacesAdded.length > 0) {
+    lines.push(`Marketplaces registered: ${nativeResult.marketplacesAdded.join(', ')}`);
+  }
+
+  for (const plugin of nativeResult.pluginsInstalled) {
+    lines.push(`  + ${plugin} (installed via claude CLI)`);
+  }
+
+  for (const { plugin, error } of nativeResult.pluginsFailed) {
+    lines.push(`  ✗ ${plugin}: ${error}`);
+  }
+
+  for (const plugin of nativeResult.skipped) {
+    lines.push(`  ⊘ ${plugin} (skipped — not a marketplace plugin)`);
+  }
+
+  return lines;
+}
+
+/**
  * Build a JSON-friendly sync data object from a sync result.
  */
 export function buildSyncData(result: SyncResult) {
@@ -65,6 +91,14 @@ export function buildSyncData(result: SyncResult) {
         overwrittenServers: result.mcpResult.overwrittenServers,
         removedServers: result.mcpResult.removedServers,
         ...(result.mcpResult.configPath && { configPath: result.mcpResult.configPath }),
+      },
+    }),
+    ...(result.nativeResult && {
+      nativePlugins: {
+        installed: result.nativeResult.pluginsInstalled,
+        failed: result.nativeResult.pluginsFailed,
+        skipped: result.nativeResult.skipped,
+        marketplacesAdded: result.nativeResult.marketplacesAdded,
       },
     }),
   };

--- a/src/cli/tui/actions/sync.ts
+++ b/src/cli/tui/actions/sync.ts
@@ -1,6 +1,6 @@
 import * as p from '@clack/prompts';
 import { syncWorkspace, syncUserWorkspace } from '../../../core/sync.js';
-import { formatMcpResult } from '../../format-sync.js';
+import { formatMcpResult, formatNativeResult } from '../../format-sync.js';
 import type { TuiContext } from '../context.js';
 
 /**
@@ -27,6 +27,9 @@ export async function runSync(context: TuiContext): Promise<void> {
         lines.push(
           `Copied: ${result.totalCopied}  Failed: ${result.totalFailed}  Skipped: ${result.totalSkipped}`,
         );
+        if (result.nativeResult) {
+          lines.push(...formatNativeResult(result.nativeResult));
+        }
         p.note(lines.join('\n'), 'Project Sync');
       }
     }
@@ -49,6 +52,9 @@ export async function runSync(context: TuiContext): Promise<void> {
         );
         if (userResult.mcpResult) {
           lines.push(...formatMcpResult(userResult.mcpResult));
+        }
+        if (userResult.nativeResult) {
+          lines.push(...formatNativeResult(userResult.nativeResult));
         }
         p.note(lines.join('\n'), 'User Sync');
       }

--- a/src/core/claude-native.ts
+++ b/src/core/claude-native.ts
@@ -1,0 +1,231 @@
+import { spawn } from 'node:child_process';
+
+export interface ClaudeNativeResult {
+  success: boolean;
+  output: string;
+  error?: string;
+}
+
+export interface ClaudePluginInfo {
+  id: string;
+  version: string;
+  scope: string;
+  enabled: boolean;
+}
+
+/**
+ * Execute a claude CLI command in headless mode.
+ * Uses subcommands only — never launches interactive TUI.
+ */
+export async function executeClaudeCommand(
+  args: string[],
+  options: { cwd?: string } = {},
+): Promise<ClaudeNativeResult> {
+  return new Promise((resolve) => {
+    const proc = spawn('claude', args, {
+      cwd: options.cwd,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: { ...process.env },
+    });
+
+    let stdout = '';
+    let stderr = '';
+
+    proc.stdout.on('data', (data: Buffer) => {
+      stdout += data.toString();
+    });
+    proc.stderr.on('data', (data: Buffer) => {
+      stderr += data.toString();
+    });
+
+    proc.on('close', (code: number | null) => {
+      resolve({
+        success: code === 0,
+        output: stdout.trim(),
+        error: stderr.trim() || undefined,
+      });
+    });
+
+    proc.on('error', (err: Error) => {
+      resolve({
+        success: false,
+        output: '',
+        error: `Failed to execute claude CLI: ${err.message}`,
+      });
+    });
+  });
+}
+
+/**
+ * Check if the claude CLI is available.
+ */
+export async function isClaudeCliAvailable(): Promise<boolean> {
+  const result = await executeClaudeCommand(['--version']);
+  return result.success;
+}
+
+/**
+ * Register a marketplace with the claude CLI.
+ * Idempotent — ignores errors if already registered.
+ */
+export async function addMarketplace(
+  source: string,
+  options: { cwd?: string } = {},
+): Promise<ClaudeNativeResult> {
+  return executeClaudeCommand(
+    ['plugin', 'marketplace', 'add', source],
+    options,
+  );
+}
+
+/**
+ * Install a plugin using the claude CLI.
+ */
+export async function installPlugin(
+  pluginSpec: string,
+  scope: 'user' | 'project' = 'project',
+  options: { cwd?: string } = {},
+): Promise<ClaudeNativeResult> {
+  return executeClaudeCommand(
+    ['plugin', 'install', pluginSpec, '--scope', scope],
+    options,
+  );
+}
+
+/**
+ * Uninstall a plugin using the claude CLI.
+ */
+export async function uninstallPlugin(
+  pluginSpec: string,
+  scope: 'user' | 'project' = 'project',
+  options: { cwd?: string } = {},
+): Promise<ClaudeNativeResult> {
+  return executeClaudeCommand(
+    ['plugin', 'uninstall', pluginSpec, '--scope', scope],
+    options,
+  );
+}
+
+/**
+ * List installed plugins using the claude CLI.
+ */
+export async function listInstalledPlugins(
+  options: { cwd?: string } = {},
+): Promise<ClaudePluginInfo[]> {
+  const result = await executeClaudeCommand(
+    ['plugin', 'list', '--json'],
+    options,
+  );
+  if (!result.success) return [];
+  try {
+    return JSON.parse(result.output) as ClaudePluginInfo[];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Extract marketplace source (owner/repo) from a plugin spec.
+ * Returns null if not in "plugin@owner/repo" format.
+ */
+export function extractMarketplaceSource(pluginSpec: string): string | null {
+  const atIndex = pluginSpec.lastIndexOf('@');
+  if (atIndex <= 0 || atIndex === pluginSpec.length - 1) return null;
+  const marketplacePart = pluginSpec.slice(atIndex + 1);
+  if (marketplacePart.includes('/') && !marketplacePart.includes('://')) {
+    return marketplacePart;
+  }
+  return null;
+}
+
+/**
+ * Convert an allagents plugin source to a claude CLI plugin spec.
+ *
+ * "superpowers@obra/superpowers-marketplace" → "superpowers@superpowers-marketplace"
+ * "vercel-labs/agent-browser/skills/agent-browser" → null (not marketplace-based)
+ */
+export function toClaudePluginSpec(allagentsSource: string): string | null {
+  const atIndex = allagentsSource.lastIndexOf('@');
+  if (atIndex <= 0 || atIndex === allagentsSource.length - 1) return null;
+
+  const pluginName = allagentsSource.slice(0, atIndex);
+  const marketplacePart = allagentsSource.slice(atIndex + 1);
+
+  if (marketplacePart.includes('/') && !marketplacePart.includes('://')) {
+    const parts = marketplacePart.split('/');
+    const repoName = parts[1];
+    return `${pluginName}@${repoName}`;
+  }
+  return allagentsSource;
+}
+
+export interface NativeSyncResult {
+  marketplacesAdded: string[];
+  pluginsInstalled: string[];
+  pluginsFailed: { plugin: string; error: string }[];
+  skipped: string[];
+}
+
+/**
+ * Sync plugins using claude CLI native commands.
+ * Registers marketplaces and installs plugins.
+ */
+export async function syncNativePlugins(
+  plugins: string[],
+  scope: 'user' | 'project' = 'project',
+  options: { cwd?: string; dryRun?: boolean } = {},
+): Promise<NativeSyncResult> {
+  const result: NativeSyncResult = {
+    marketplacesAdded: [],
+    pluginsInstalled: [],
+    pluginsFailed: [],
+    skipped: [],
+  };
+
+  if (options.dryRun) {
+    for (const plugin of plugins) {
+      const spec = toClaudePluginSpec(plugin);
+      if (spec) {
+        result.pluginsInstalled.push(spec);
+      } else {
+        result.skipped.push(plugin);
+      }
+    }
+    return result;
+  }
+
+  // Register unique marketplaces
+  const marketplaceSources = new Set<string>();
+  for (const plugin of plugins) {
+    const source = extractMarketplaceSource(plugin);
+    if (source) marketplaceSources.add(source);
+  }
+
+  for (const source of marketplaceSources) {
+    const addResult = await addMarketplace(source, options);
+    if (addResult.success) {
+      result.marketplacesAdded.push(source);
+    }
+  }
+
+  // Install plugins
+  for (const plugin of plugins) {
+    const spec = toClaudePluginSpec(plugin);
+    if (!spec) {
+      result.skipped.push(plugin);
+      continue;
+    }
+
+    const installResult = await installPlugin(spec, scope, options);
+    if (installResult.success) {
+      result.pluginsInstalled.push(spec);
+    } else {
+      result.pluginsFailed.push({
+        plugin: spec,
+        error: installResult.error ?? 'Unknown error',
+      });
+    }
+  }
+
+  return result;
+}

--- a/src/core/claude-native.ts
+++ b/src/core/claude-native.ts
@@ -39,10 +39,11 @@ export async function executeClaudeCommand(
     });
 
     proc.on('close', (code: number | null) => {
+      const trimmedStderr = stderr.trim();
       resolve({
         success: code === 0,
         output: stdout.trim(),
-        error: stderr.trim() || undefined,
+        ...(trimmedStderr && { error: trimmedStderr }),
       });
     });
 

--- a/src/core/claude-native.ts
+++ b/src/core/claude-native.ts
@@ -38,7 +38,10 @@ export async function executeClaudeCommand(
       stderr += data.toString();
     });
 
+    let resolved = false;
     proc.on('close', (code: number | null) => {
+      if (resolved) return;
+      resolved = true;
       const trimmedStderr = stderr.trim();
       resolve({
         success: code === 0,
@@ -48,6 +51,8 @@ export async function executeClaudeCommand(
     });
 
     proc.on('error', (err: Error) => {
+      if (resolved) return;
+      resolved = true;
       resolve({
         success: false,
         output: '',
@@ -155,6 +160,7 @@ export function toClaudePluginSpec(allagentsSource: string): string | null {
   if (marketplacePart.includes('/') && !marketplacePart.includes('://')) {
     const parts = marketplacePart.split('/');
     const repoName = parts[1];
+    if (!repoName) return null;
     return `${pluginName}@${repoName}`;
   }
   return allagentsSource;

--- a/src/core/sync-state.ts
+++ b/src/core/sync-state.ts
@@ -14,6 +14,7 @@ export type McpScope = 'vscode';
 export interface SyncStateData {
   files: Partial<Record<ClientType, string[]>>;
   mcpServers?: Partial<Record<McpScope, string[]>>;
+  nativePlugins?: string[];
 }
 
 /**
@@ -76,6 +77,7 @@ export async function saveSyncState(
     lastSync: new Date().toISOString(),
     files: normalizedData.files as Record<ClientType, string[]>,
     ...(normalizedData.mcpServers && { mcpServers: normalizedData.mcpServers }),
+    ...(normalizedData.nativePlugins && { nativePlugins: normalizedData.nativePlugins }),
   };
 
   await mkdir(dirname(statePath), { recursive: true });
@@ -114,4 +116,13 @@ export function getPreviouslySyncedMcpServers(
   }
 
   return state.mcpServers[scope] ?? [];
+}
+
+/**
+ * Get native plugins that were previously installed via claude CLI
+ */
+export function getPreviouslySyncedNativePlugins(
+  state: SyncState | null,
+): string[] {
+  return state?.nativePlugins ?? [];
 }

--- a/src/core/sync.ts
+++ b/src/core/sync.ts
@@ -1470,7 +1470,11 @@ export async function syncWorkspace(
     }
 
     // Track native plugins in sync state for declarative uninstall on next sync
-    const nativePluginsToTrack = nativeResult?.pluginsInstalled ?? [];
+    // When syncing a subset of clients that excludes claude-native, preserve previous state
+    const nativePluginsToTrack = nativeResult?.pluginsInstalled
+      ?? (options.clients && !syncClients.includes('claude-native' as ClientType)
+        ? previousState?.nativePlugins ?? []
+        : []);
 
     await saveSyncState(workspacePath, {
       files: syncedFiles,

--- a/src/core/sync.ts
+++ b/src/core/sync.ts
@@ -51,6 +51,7 @@ import {
 } from './vscode-workspace.js';
 import { syncVscodeMcpConfig } from './vscode-mcp.js';
 import type { McpMergeResult } from './vscode-mcp.js';
+import { syncNativePlugins, isClaudeCliAvailable, type NativeSyncResult } from './claude-native.js';
 
 /**
  * Result of deduplicating clients by skillsPath
@@ -122,6 +123,8 @@ export interface SyncResult {
   warnings?: string[];
   /** Result of syncing MCP server configs to VS Code */
   mcpResult?: McpMergeResult;
+  /** Result of native CLI plugin installations (claude-native client) */
+  nativeResult?: NativeSyncResult;
 }
 
 /**
@@ -130,8 +133,8 @@ export interface SyncResult {
 export function mergeSyncResults(a: SyncResult, b: SyncResult): SyncResult {
   const warnings = [...(a.warnings || []), ...(b.warnings || [])];
   const purgedPaths = [...(a.purgedPaths || []), ...(b.purgedPaths || [])];
-  // Use whichever mcpResult is present (only user-scope sync produces one)
   const mcpResult = a.mcpResult ?? b.mcpResult;
+  const nativeResult = a.nativeResult ?? b.nativeResult;
   return {
     success: a.success && b.success,
     pluginResults: [...a.pluginResults, ...b.pluginResults],
@@ -142,7 +145,15 @@ export function mergeSyncResults(a: SyncResult, b: SyncResult): SyncResult {
     ...(warnings.length > 0 && { warnings }),
     ...(purgedPaths.length > 0 && { purgedPaths }),
     ...(mcpResult && { mcpResult }),
+    ...(nativeResult && { nativeResult }),
   };
+}
+
+/**
+ * Check if a client uses native CLI installation instead of file-based sync.
+ */
+export function isNativeClient(client: ClientType): boolean {
+  return client === 'claude-native';
 }
 
 /**
@@ -855,7 +866,17 @@ async function copyValidatedPlugin(
 ): Promise<PluginSyncResult> {
   const copyResults: CopyResult[] = [];
   const mappings = clientMappings ?? CLIENT_MAPPINGS;
-  const clientList = clients;
+  // Filter out native clients — they don't use file-based sync
+  const clientList = clients.filter((c) => !isNativeClient(c));
+
+  if (clientList.length === 0) {
+    return {
+      plugin: validatedPlugin.plugin,
+      resolved: validatedPlugin.resolved,
+      success: true,
+      copyResults: [],
+    };
+  }
 
   const hasUniversalClient = clientList.some((c) => isUniversalClient(c));
 
@@ -1406,6 +1427,34 @@ export async function syncWorkspace(
     await saveSyncState(workspacePath, syncedFiles);
   }
 
+  // Step 7: Run native CLI installations for claude-native client
+  let nativeResult: NativeSyncResult | undefined;
+  if (syncClients.includes('claude-native' as ClientType)) {
+    const nativePluginSources = pluginPlans
+      .filter((plan) => plan.clients.includes('claude-native' as ClientType))
+      .map((plan) => plan.source);
+
+    if (nativePluginSources.length > 0) {
+      if (dryRun) {
+        nativeResult = await syncNativePlugins(nativePluginSources, 'project', {
+          cwd: workspacePath,
+          dryRun: true,
+        });
+      } else {
+        const cliAvailable = await isClaudeCliAvailable();
+        if (cliAvailable) {
+          nativeResult = await syncNativePlugins(nativePluginSources, 'project', {
+            cwd: workspacePath,
+          });
+        } else {
+          warnings.push(
+            'claude-native: claude CLI not found, skipping native plugin installation',
+          );
+        }
+      }
+    }
+  }
+
   return {
     success: !hasFailures,
     pluginResults,
@@ -1415,6 +1464,7 @@ export async function syncWorkspace(
     totalGenerated,
     purgedPaths,
     ...(warnings.length > 0 && { warnings }),
+    ...(nativeResult && { nativeResult }),
   };
 }
 
@@ -1543,6 +1593,31 @@ export async function syncUserWorkspace(
     });
   }
 
+  // Step: Run native CLI installations for claude-native client (user scope)
+  let nativeResult: NativeSyncResult | undefined;
+  if (syncClients.includes('claude-native' as ClientType)) {
+    const nativePluginSources = pluginPlans
+      .filter((plan) => plan.clients.includes('claude-native' as ClientType))
+      .map((plan) => plan.source);
+
+    if (nativePluginSources.length > 0) {
+      if (dryRun) {
+        nativeResult = await syncNativePlugins(nativePluginSources, 'user', {
+          dryRun: true,
+        });
+      } else {
+        const cliAvailable = await isClaudeCliAvailable();
+        if (cliAvailable) {
+          nativeResult = await syncNativePlugins(nativePluginSources, 'user');
+        } else {
+          warnings.push(
+            'claude-native: claude CLI not found, skipping native plugin installation',
+          );
+        }
+      }
+    }
+  }
+
   return {
     success: totalFailed === 0,
     pluginResults,
@@ -1552,5 +1627,6 @@ export async function syncUserWorkspace(
     totalGenerated,
     ...(warnings.length > 0 && { warnings }),
     ...(mcpResult && { mcpResult }),
+    ...(nativeResult && { nativeResult }),
   };
 }

--- a/src/core/sync.ts
+++ b/src/core/sync.ts
@@ -42,6 +42,7 @@ import {
   saveSyncState,
   getPreviouslySyncedFiles,
   getPreviouslySyncedMcpServers,
+  getPreviouslySyncedNativePlugins,
 } from './sync-state.js';
 import type { SyncState } from '../models/sync-state.js';
 import { getUserWorkspaceConfig } from './user-workspace.js';
@@ -51,7 +52,7 @@ import {
 } from './vscode-workspace.js';
 import { syncVscodeMcpConfig } from './vscode-mcp.js';
 import type { McpMergeResult } from './vscode-mcp.js';
-import { syncNativePlugins, isClaudeCliAvailable, type NativeSyncResult } from './claude-native.js';
+import { syncNativePlugins, isClaudeCliAvailable, uninstallPlugin, toClaudePluginSpec, type NativeSyncResult } from './claude-native.js';
 
 /**
  * Result of deduplicating clients by skillsPath
@@ -1405,6 +1406,50 @@ export async function syncWorkspace(
   // Step 6: Save sync state with all copied files (skip in dry-run mode)
   // Always save state after sync (even with partial failures) so state reflects disk reality.
   // The purge has already happened, so we need to track what was actually copied.
+
+  // Step 7: Run native CLI installations for claude-native client
+  let nativeResult: NativeSyncResult | undefined;
+  if (syncClients.includes('claude-native' as ClientType)) {
+    const nativePluginSources = pluginPlans
+      .filter((plan) => plan.clients.includes('claude-native' as ClientType))
+      .map((plan) => plan.source);
+
+    // Convert to claude plugin specs for comparison with previous state
+    const currentNativeSpecs = nativePluginSources
+      .map((s) => toClaudePluginSpec(s))
+      .filter((s): s is string => s !== null);
+
+    if (!dryRun) {
+      const cliAvailable = await isClaudeCliAvailable();
+      if (cliAvailable) {
+        // Uninstall plugins that were previously installed but no longer in config
+        const previousNativePlugins = getPreviouslySyncedNativePlugins(previousState);
+        const removedPlugins = previousNativePlugins.filter(
+          (p) => !currentNativeSpecs.includes(p),
+        );
+        for (const plugin of removedPlugins) {
+          await uninstallPlugin(plugin, 'project', { cwd: workspacePath });
+        }
+
+        if (nativePluginSources.length > 0) {
+          nativeResult = await syncNativePlugins(nativePluginSources, 'project', {
+            cwd: workspacePath,
+          });
+        }
+      } else {
+        warnings.push(
+          'claude-native: claude CLI not found, skipping native plugin installation',
+        );
+      }
+    } else if (nativePluginSources.length > 0) {
+      nativeResult = await syncNativePlugins(nativePluginSources, 'project', {
+        cwd: workspacePath,
+        dryRun: true,
+      });
+    }
+  }
+
+  // Step 8: Save sync state (skip in dry-run mode)
   if (!dryRun) {
     // Collect all copy results
     const allCopyResults: CopyResult[] = [
@@ -1424,35 +1469,13 @@ export async function syncWorkspace(
       }
     }
 
-    await saveSyncState(workspacePath, syncedFiles);
-  }
+    // Track native plugins in sync state for declarative uninstall on next sync
+    const nativePluginsToTrack = nativeResult?.pluginsInstalled ?? [];
 
-  // Step 7: Run native CLI installations for claude-native client
-  let nativeResult: NativeSyncResult | undefined;
-  if (syncClients.includes('claude-native' as ClientType)) {
-    const nativePluginSources = pluginPlans
-      .filter((plan) => plan.clients.includes('claude-native' as ClientType))
-      .map((plan) => plan.source);
-
-    if (nativePluginSources.length > 0) {
-      if (dryRun) {
-        nativeResult = await syncNativePlugins(nativePluginSources, 'project', {
-          cwd: workspacePath,
-          dryRun: true,
-        });
-      } else {
-        const cliAvailable = await isClaudeCliAvailable();
-        if (cliAvailable) {
-          nativeResult = await syncNativePlugins(nativePluginSources, 'project', {
-            cwd: workspacePath,
-          });
-        } else {
-          warnings.push(
-            'claude-native: claude CLI not found, skipping native plugin installation',
-          );
-        }
-      }
-    }
+    await saveSyncState(workspacePath, {
+      files: syncedFiles,
+      ...(nativePluginsToTrack.length > 0 && { nativePlugins: nativePluginsToTrack }),
+    });
   }
 
   return {
@@ -1583,39 +1606,53 @@ export async function syncUserWorkspace(
     }
   }
 
-  // Save sync state (including MCP servers)
-  if (!dryRun) {
-    const allCopyResults = pluginResults.flatMap((r) => r.copyResults);
-    const syncedFiles = collectSyncedPaths(allCopyResults, homeDir, syncClients, USER_CLIENT_MAPPINGS);
-    await saveSyncState(homeDir, {
-      files: syncedFiles,
-      ...(mcpResult && { mcpServers: { vscode: mcpResult.trackedServers } }),
-    });
-  }
-
-  // Step: Run native CLI installations for claude-native client (user scope)
+  // Run native CLI installations for claude-native client (user scope)
   let nativeResult: NativeSyncResult | undefined;
   if (syncClients.includes('claude-native' as ClientType)) {
     const nativePluginSources = pluginPlans
       .filter((plan) => plan.clients.includes('claude-native' as ClientType))
       .map((plan) => plan.source);
 
-    if (nativePluginSources.length > 0) {
-      if (dryRun) {
-        nativeResult = await syncNativePlugins(nativePluginSources, 'user', {
-          dryRun: true,
-        });
-      } else {
-        const cliAvailable = await isClaudeCliAvailable();
-        if (cliAvailable) {
-          nativeResult = await syncNativePlugins(nativePluginSources, 'user');
-        } else {
-          warnings.push(
-            'claude-native: claude CLI not found, skipping native plugin installation',
-          );
+    const currentNativeSpecs = nativePluginSources
+      .map((s) => toClaudePluginSpec(s))
+      .filter((s): s is string => s !== null);
+
+    if (!dryRun) {
+      const cliAvailable = await isClaudeCliAvailable();
+      if (cliAvailable) {
+        const previousNativePlugins = getPreviouslySyncedNativePlugins(previousState);
+        const removedPlugins = previousNativePlugins.filter(
+          (p) => !currentNativeSpecs.includes(p),
+        );
+        for (const plugin of removedPlugins) {
+          await uninstallPlugin(plugin, 'user');
         }
+
+        if (nativePluginSources.length > 0) {
+          nativeResult = await syncNativePlugins(nativePluginSources, 'user');
+        }
+      } else {
+        warnings.push(
+          'claude-native: claude CLI not found, skipping native plugin installation',
+        );
       }
+    } else if (nativePluginSources.length > 0) {
+      nativeResult = await syncNativePlugins(nativePluginSources, 'user', {
+        dryRun: true,
+      });
     }
+  }
+
+  // Save sync state (including MCP servers and native plugins)
+  if (!dryRun) {
+    const allCopyResults = pluginResults.flatMap((r) => r.copyResults);
+    const syncedFiles = collectSyncedPaths(allCopyResults, homeDir, syncClients, USER_CLIENT_MAPPINGS);
+    const nativePluginsToTrack = nativeResult?.pluginsInstalled ?? [];
+    await saveSyncState(homeDir, {
+      files: syncedFiles,
+      ...(mcpResult && { mcpServers: { vscode: mcpResult.trackedServers } }),
+      ...(nativePluginsToTrack.length > 0 && { nativePlugins: nativePluginsToTrack }),
+    });
   }
 
   return {

--- a/src/core/user-workspace.ts
+++ b/src/core/user-workspace.ts
@@ -8,7 +8,7 @@ import type {
   PluginEntry,
   WorkspaceConfig,
 } from '../models/workspace-config.js';
-import { getPluginSource } from '../models/workspace-config.js';
+import { getPluginClients, getPluginSource } from '../models/workspace-config.js';
 import { parseMarketplaceManifest } from '../utils/marketplace-manifest-parser.js';
 import {
   isGitHubUrl,
@@ -484,6 +484,8 @@ export interface InstalledPluginInfo {
   marketplace: string;
   /** Installation scope */
   scope: PluginScope;
+  /** Per-plugin client overrides (if specified in workspace.yaml) */
+  clients?: ClientType[];
 }
 
 /**
@@ -497,15 +499,18 @@ export async function getInstalledUserPlugins(): Promise<
   if (!config) return [];
 
   const result: InstalledPluginInfo[] = [];
+  const defaultClients = config.clients;
   for (const pluginEntry of config.plugins) {
     const plugin = getPluginSource(pluginEntry);
     const parsed = parsePluginSpec(plugin);
     if (parsed) {
+      const clients = getPluginClients(pluginEntry) ?? defaultClients;
       result.push({
         spec: plugin,
         name: parsed.plugin,
         marketplace: parsed.marketplaceName,
         scope: 'user',
+        ...(clients && { clients }),
       });
     }
   }
@@ -528,15 +533,18 @@ export async function getInstalledProjectPlugins(
     if (!config?.plugins) return [];
 
     const result: InstalledPluginInfo[] = [];
+    const defaultClients = config.clients;
     for (const pluginEntry of config.plugins) {
       const plugin = getPluginSource(pluginEntry);
       const parsed = parsePluginSpec(plugin);
       if (parsed) {
+        const clients = getPluginClients(pluginEntry) ?? defaultClients;
         result.push({
           spec: plugin,
           name: parsed.plugin,
           marketplace: parsed.marketplaceName,
           scope: 'project',
+          ...(clients && { clients }),
         });
       }
     }

--- a/src/models/client-mapping.ts
+++ b/src/models/client-mapping.ts
@@ -34,6 +34,11 @@ export const CLIENT_MAPPINGS: Record<ClientType, ClientMapping> = {
     agentFileFallback: 'AGENTS.md',
     hooksPath: '.claude/hooks/',
   },
+  'claude-native': {
+    skillsPath: '',
+    agentFile: 'CLAUDE.md',
+    agentFileFallback: 'AGENTS.md',
+  },
   copilot: {
     skillsPath: '.github/skills/',
     agentFile: 'AGENTS.md',
@@ -161,6 +166,11 @@ export const USER_CLIENT_MAPPINGS: Record<ClientType, ClientMapping> = {
     agentFile: 'CLAUDE.md',
     agentFileFallback: 'AGENTS.md',
     hooksPath: '.claude/hooks/',
+  },
+  'claude-native': {
+    skillsPath: '',
+    agentFile: 'CLAUDE.md',
+    agentFileFallback: 'AGENTS.md',
   },
   copilot: {
     skillsPath: '.copilot/skills/',

--- a/src/models/sync-state.ts
+++ b/src/models/sync-state.ts
@@ -11,6 +11,8 @@ export const SyncStateSchema = z.object({
   files: z.record(ClientTypeSchema, z.array(z.string())),
   // MCP servers tracked per scope (e.g., "vscode" for user-level mcp.json)
   mcpServers: z.record(z.string(), z.array(z.string())).optional(),
+  // Plugins installed via claude-native CLI (for declarative uninstall on re-sync)
+  nativePlugins: z.array(z.string()).optional(),
 });
 
 export type SyncState = z.infer<typeof SyncStateSchema>;

--- a/src/models/workspace-config.ts
+++ b/src/models/workspace-config.ts
@@ -65,6 +65,7 @@ export type PluginSource = z.infer<typeof PluginSourceSchema>;
  */
 export const ClientTypeSchema = z.enum([
   'claude',
+  'claude-native',
   'copilot',
   'codex',
   'cursor',

--- a/tests/unit/core/claude-native.test.ts
+++ b/tests/unit/core/claude-native.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  toClaudePluginSpec,
+  extractMarketplaceSource,
+} from '../../../src/core/claude-native.js';
+
+describe('claude-native', () => {
+  describe('toClaudePluginSpec', () => {
+    test('converts marketplace spec with owner/repo to plugin@repo', () => {
+      expect(toClaudePluginSpec('superpowers@obra/superpowers-marketplace')).toBe(
+        'superpowers@superpowers-marketplace',
+      );
+    });
+
+    test('preserves plugin@marketplace format', () => {
+      expect(toClaudePluginSpec('superpowers@superpowers-marketplace')).toBe(
+        'superpowers@superpowers-marketplace',
+      );
+    });
+
+    test('returns null for direct GitHub paths', () => {
+      expect(
+        toClaudePluginSpec('vercel-labs/agent-browser/skills/agent-browser'),
+      ).toBeNull();
+    });
+
+    test('returns null for empty string', () => {
+      expect(toClaudePluginSpec('')).toBeNull();
+    });
+  });
+
+  describe('extractMarketplaceSource', () => {
+    test('extracts owner/repo from marketplace spec', () => {
+      expect(
+        extractMarketplaceSource('superpowers@obra/superpowers-marketplace'),
+      ).toBe('obra/superpowers-marketplace');
+    });
+
+    test('returns null for non-marketplace specs', () => {
+      expect(
+        extractMarketplaceSource('vercel-labs/agent-browser/skills/agent-browser'),
+      ).toBeNull();
+    });
+
+    test('returns null for plain marketplace name', () => {
+      expect(
+        extractMarketplaceSource('superpowers@superpowers-marketplace'),
+      ).toBeNull();
+    });
+  });
+});

--- a/tests/unit/core/claude-native.test.ts
+++ b/tests/unit/core/claude-native.test.ts
@@ -27,6 +27,10 @@ describe('claude-native', () => {
     test('returns null for empty string', () => {
       expect(toClaudePluginSpec('')).toBeNull();
     });
+
+    test('returns null for trailing slash in marketplace', () => {
+      expect(toClaudePluginSpec('plugin@owner/')).toBeNull();
+    });
   });
 
   describe('extractMarketplaceSource', () => {


### PR DESCRIPTION
Closes #141

Adds `claude-native` client type that uses the `claude` CLI to install plugins natively, instead of copying files to `.claude/` directories.

## What this does
- Adds `claude-native` as a new client type in workspace config
- Registers marketplaces via `claude plugin marketplace add`
- Installs plugins via `claude plugin install <spec> --scope project`
- Tracks native plugins in sync state for declarative uninstall on re-sync
- Displays native install results in CLI output (commands, TUI)
- Supports both project and user scope

## How to use
```yaml
clients:
  - claude-native

plugins:
  - source: superpowers@obra/superpowers-marketplace
    clients:
      - claude-native
```

## Key design decisions
- Native clients are filtered out of file-based copy operations (empty `skillsPath`)
- Only marketplace plugins (`plugin@marketplace` format) are supported — direct GitHub paths are skipped
- Marketplace registration is idempotent (errors from existing marketplaces are ignored)
- Plugin tracking in `sync-state.json` enables declarative uninstall when plugins are removed from config

## Testing
- 7 unit tests for spec conversion functions (`toClaudePluginSpec`, `extractMarketplaceSource`)
- All 694 existing tests pass (0 failures)
- E2E validated with example workspace (`examples/workspaces/claude-native/`)
- Lint, typecheck, and test hooks pass
