### PR TITLE
fix(sync): reuse deep URL branch cache

### DIFF
--- a/src/core/plugin.ts
+++ b/src/core/plugin.ts
@@ -157,7 +157,8 @@ export async function fetchPlugin(
   }
 
   const { owner, repo } = parsed;
-  const cachePath = getPluginCachePath(owner, repo, branch);
+  const effectiveBranch = branch ?? parsed.branch;
+  const cachePath = getPluginCachePath(owner, repo, effectiveBranch);
 
   // Return cached result if this repo was already fetched this session
   const cached = fetchCache.get(cachePath);
@@ -170,7 +171,7 @@ export async function fetchPlugin(
     owner,
     repo,
     offline,
-    branch,
+    effectiveBranch,
     deps,
   );
   fetchCache.set(cachePath, promise);

--- a/tests/unit/core/plugin.test.ts
+++ b/tests/unit/core/plugin.test.ts
@@ -56,6 +56,42 @@ describe('fetchPlugin', () => {
     expect(result.cachePath).toContain('owner-repo');
   });
 
+  it('uses the branch encoded in a deep GitHub URL', async () => {
+    existsSyncMock.mockReturnValueOnce(false);
+
+    const result = await fetchPlugin(
+      'https://github.com/owner/repo/blob/main/skills/example',
+      {},
+      deps,
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.cachePath).toContain('owner-repo@main');
+    expect(cloneToMock).toHaveBeenCalledWith(
+      'https://github.com/owner/repo.git',
+      expect.stringContaining('owner-repo@main'),
+      'main',
+    );
+  });
+
+  it('prefers an explicit branch override to the URL branch', async () => {
+    existsSyncMock.mockReturnValueOnce(false);
+
+    const result = await fetchPlugin(
+      'https://github.com/owner/repo/blob/main/skills/example',
+      { branch: 'release' },
+      deps,
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.cachePath).toContain('owner-repo@release');
+    expect(cloneToMock).toHaveBeenCalledWith(
+      'https://github.com/owner/repo.git',
+      expect.stringContaining('owner-repo@release'),
+      'release',
+    );
+  });
+
   it('should handle authentication errors', async () => {
     existsSyncMock.mockReturnValueOnce(false);
     cloneToMock.mockRejectedValueOnce(


### PR DESCRIPTION
## Summary

- derive the fetch branch from `/tree/<branch>/...` and `/blob/<branch>/...` GitHub URLs when callers do not pass a branch override
- use that effective branch for both the cache key and git clone
- preserve explicit `FetchOptions.branch` precedence

## Problem

`fetchPlugin()` parsed the branch embedded in a deep GitHub URL but ignored it unless every caller also copied that branch into `FetchOptions`. A standalone skill URL could therefore use the unqualified repository cache and perform a second full clone instead of reusing its existing `@main` cache. For the Hermes Agent repository this left `allagents update` silent long enough to appear stuck.

## Verification

- `bun test tests/unit/core/plugin.test.ts` — 17 passed
- `bun run typecheck`
- `bun run lint` — 92 files checked
- `bun run build`

### E2E

From `/home/christso/.openclaw/agent-profiles/profiles/scout`:

```sh
/home/christso/projects/EntityProcess/allagents-skill-sync-update-hang/dist/index.js update
```

Observed exit 0 in 1.32 seconds and one `har-derived-api-client` skill synced for Copilot.

Deep-URL cache-key smoke check with an isolated HOME containing only the existing branch-qualified cache:

```sh
HOME=/tmp/allagents-skill-sync-repro/home ALLAGENTS_CLONE_TIMEOUT_MS=1 bun -e "import { fetchPlugin } from './src/core/plugin.ts'; const result = await fetchPlugin('https://github.com/NousResearch/hermes-agent/blob/main/optional-skills/web-development/har-derived-api-client', { offline: true }); console.log(JSON.stringify({ action: result.action, cachePath: result.cachePath }));"
```

Observed `action: skipped` with cache path ending in `NousResearch-hermes-agent@main`; no fallback clone was attempted.