### PR TITLE
feat(review): make interactive PR design reproducible

### DIFF
--- a/plugins/engineering/skills/pr-interactive-review/SKILL.md
+++ b/plugins/engineering/skills/pr-interactive-review/SKILL.md
@@ -54,6 +54,50 @@ Non-goals: Redesigning permission roles
 ```
 
 `--requirements` remains a direct file-read option only for a repository-relative path. The helper rejects paths outside the repository and `.git`; use host extraction plus `--spec` for any external specification reference.
+### Reproducible presentation
+
+Create `interactive-presentation.json` beside the scenario sidecar for every review. This is a constrained content model for the shared renderer, not a per-PR template: never generate custom HTML, CSS, or JavaScript. Ground every sentence in the structured review, supplied requirements, or reviewed repository evidence.
+
+```json
+{
+  "eyebrow": "Runtime seam review",
+  "headline": "One queue connects two services.",
+  "summary": "The change establishes the first validated Dispatcher-to-Runner workflow handoff.",
+  "context_cards": [
+    {
+      "label": "System boundary",
+      "title": "Dispatcher to Runner",
+      "body": "The Dispatcher starts resolved work; the Runner validates and completes the workflow.",
+      "tone": "neutral"
+    },
+    {
+      "label": "Operational risk",
+      "title": "A false-ready worker hides the broken seam",
+      "body": "The smoke must prove polling, not merely observe a startup log.",
+      "tone": "problem"
+    }
+  ],
+  "mental_model": {
+    "title": "The execution path",
+    "summary": "Each stage owns one boundary and hands a single contract forward.",
+    "steps": [
+      {
+        "label": "01 / Dispatch",
+        "title": "Start workflow",
+        "body": "Create a workflow on the configured Runner queue."
+      },
+      {
+        "label": "02 / Validate",
+        "title": "Reject malformed input",
+        "body": "Validate the shared payload before any execution work."
+      }
+    ]
+  }
+}
+```
+
+`eyebrow`, `headline`, and `summary` are required. Use at most six context cards and six mental-model steps. Card `tone` is `neutral`, `problem`, or `outcome`. Keep labels short, make the headline state the review's central conclusion, and use the mental model only when a real sequence or system boundary helps the reviewer decide. Omit `mental_model` rather than inventing decorative steps. The renderer supplies the navigation rail, verdict, metrics, cards, disclosures, finding layout, and responsive behavior; the sidecar supplies only grounded copy.
+
 
 ## Create a reusable workspace
 
@@ -64,6 +108,7 @@ SKILL_DIR="<directory containing this SKILL.md>"
 bun "$SKILL_DIR/scripts/review-site.ts" prepare \
   --review-json "<artifact_path>/review.json" \
   --scenarios "<artifact_path>/interactive-scenarios.json" \
+  --presentation "<artifact_path>/interactive-presentation.json" \
   --pr 123 \
   --spec "Who configures: Release managers
 Operational problem: Manual approval queues delay configuration changes
@@ -80,11 +125,13 @@ For a repository-relative requirements reference, use:
 bun "$SKILL_DIR/scripts/review-site.ts" prepare \
   --review-json "<artifact_path>/review.json" \
   --scenarios "<artifact_path>/interactive-scenarios.json" \
+  --presentation "<artifact_path>/interactive-presentation.json" \
   --pr https://github.com/example-org/sample-service/pull/123 \
   --requirements docs/requirements.md
 ```
 
-`prepare` prints the per-repository, per-PR workspace path. It validates the review artifact, scenario sidecar, PR identifier, finding file paths, sizes, and requirements reference. It generates GitHub source links only when the runtime `origin` remote is GitHub. Links pin the reviewed commit and exact cited line range. Non-GitHub remotes receive no external link.
+`prepare` prints the per-repository, per-PR workspace path. It validates the review artifact, scenario and presentation sidecars, PR identifier, finding file paths, sizes, and requirements reference. It generates GitHub source links only when the runtime `origin` remote is GitHub. Links pin the reviewed commit and exact cited line range. Non-GitHub remotes receive no external link. Existing workspaces without presentation metadata still render through the same shell using the review title, intent, and primer fields as safe fallbacks.
+
 
 For focused code context, `prepare` reads only the cited relative paths at the reviewed commit. Pass `--base-commit <sha>` only when the review already supplied a verified exact base SHA; the helper does not rediscover PR scope. When no base or reviewed object is locally readable, the site labels that gap instead of substituting current-worktree content.
 
@@ -94,7 +141,8 @@ For focused code context, `prepare` reads only the cited relative paths at the r
 bun "$SKILL_DIR/scripts/review-site.ts" serve --workspace "<printed workspace>"
 ```
 
-Open the printed loopback URL. The page places **Business context** before findings, includes severity navigation and search, exact reviewed-commit links, required response, reviewers, confidence, structured evidence, available focused excerpts, and comments.
+Open the printed loopback URL. The shared page renders a sticky review map, current verdict, headline and metrics, business context, an optional mental model, status-grouped findings, search and filters, exact reviewed-commit links, paired actual/expected scenarios, required responses, and local comments. Supplied requirements, referenced evidence, lifecycle history, code excerpts, and per-finding discussion use collapsed disclosures so large reviews remain scannable.
+
 
 LAN or public exposure is opt-in and must be deliberate:
 
@@ -135,5 +183,5 @@ Refresh the site and unanswered queue until the queue is empty. Never treat this
 
 ## Completion
 1. Confirm the review artifact was consumed as JSON, not markdown.
-2. Browser-check the local site: business context comes first; active findings, open questions, and withdrawn findings are visibly separate; verdict/counts exclude withdrawn findings; every finding shows `What actually happens` and `Expected / suggested` (or an explicit evidence gap); severity/status filters and search work; the responsive layout works; a local comment, assistant reply, and lifecycle revision render; a GitHub remote produces a reviewed-commit line link.
+2. Browser-check the local site with representative review data, not an empty fixture: the desktop view has the navigation rail, verdict, hero metrics, business context, and indexed finding links; the narrow view stacks cleanly with no document-level horizontal overflow; raw requirements, evidence, and code are closed by default; active findings, open questions, and withdrawn findings are visibly separate; verdict/counts exclude withdrawn findings; every finding shows paired `What actually happens` and `Expected / suggested` content (or an explicit evidence gap); severity/status filters and search work; a local comment, assistant reply, and lifecycle revision render; and a GitHub remote produces a reviewed-commit line link.
 3. State the workspace path and loopback URL. Do not include comment text, credentials, or source contents in the report.

--- a/plugins/engineering/skills/pr-interactive-review/scripts/review-site.ts
+++ b/plugins/engineering/skills/pr-interactive-review/scripts/review-site.ts
@@ -79,6 +79,33 @@ export interface PrimerField {
   value: string | null;
   evidenceGap: string | null;
 }
+export type PresentationTone = 'neutral' | 'problem' | 'outcome';
+
+export interface PresentationCard {
+  label: string;
+  title: string;
+  body: string;
+  tone: PresentationTone;
+}
+
+export interface PresentationStep {
+  label: string;
+  title: string;
+  body: string;
+}
+
+export interface ReviewPresentation {
+  eyebrow: string;
+  headline: string;
+  summary: string;
+  contextCards: PresentationCard[];
+  mentalModel: {
+    title: string;
+    summary: string | null;
+    steps: PresentationStep[];
+  } | null;
+}
+
 
 export interface StoredReview {
   version: 2;
@@ -91,6 +118,8 @@ export interface StoredReview {
   verdict: string;
   intent: string;
   primer: BusinessPrimer;
+  presentation: ReviewPresentation | null;
+
   findings: ReviewFinding[];
   generatedAt: string;
 }
@@ -133,6 +162,8 @@ export interface PrepareOptions {
   repoPath?: string;
   dataDir?: string;
   scenariosPath?: string;
+  presentationPath?: string;
+
   specification?: string;
   requirementsPath?: string;
   baseCommit?: string;
@@ -638,6 +669,125 @@ async function readScenarioSidecar(
   }
   return scenarios;
 }
+function recordArray(
+  value: unknown,
+  field: string,
+  maximumEntries: number,
+): JsonObject[] {
+  if (value === undefined) return [];
+  if (!Array.isArray(value) || value.length > maximumEntries)
+    throw new Error(
+      `${field} must be an array of at most ${maximumEntries} objects`,
+    );
+  return value.map((item, index) => {
+    if (!isRecord(item)) throw new Error(`${field}[${index}] must be an object`);
+    return item;
+  });
+}
+
+function normalizePresentation(
+  value: unknown,
+  field = 'presentation',
+): ReviewPresentation | null {
+  if (value === undefined || value === null) return null;
+  if (!isRecord(value)) throw new Error(`${field} must be an object`);
+  const contextCards = recordArray(
+    value.context_cards ?? value.contextCards,
+    `${field}.context_cards`,
+    6,
+  ).map((card, index): PresentationCard => {
+    const tone = (boundedString(
+      card.tone,
+      `${field}.context_cards[${index}].tone`,
+      16,
+      false,
+    ) ?? 'neutral') as PresentationTone;
+    if (!['neutral', 'problem', 'outcome'].includes(tone))
+      throw new Error(
+        `${field}.context_cards[${index}].tone must be neutral, problem, or outcome`,
+      );
+    return {
+      label: boundedString(
+        card.label,
+        `${field}.context_cards[${index}].label`,
+        120,
+      ) as string,
+      title: boundedString(
+        card.title,
+        `${field}.context_cards[${index}].title`,
+        300,
+      ) as string,
+      body: boundedString(
+        card.body,
+        `${field}.context_cards[${index}].body`,
+        3000,
+      ) as string,
+      tone,
+    };
+  });
+  const rawMentalModel = value.mental_model ?? value.mentalModel;
+  let mentalModel: ReviewPresentation['mentalModel'] = null;
+  if (rawMentalModel !== undefined && rawMentalModel !== null) {
+    if (!isRecord(rawMentalModel))
+      throw new Error(`${field}.mental_model must be an object`);
+    const steps = recordArray(
+      rawMentalModel.steps,
+      `${field}.mental_model.steps`,
+      6,
+    );
+    if (!steps.length)
+      throw new Error(`${field}.mental_model.steps must not be empty`);
+    mentalModel = {
+      title: boundedString(
+        rawMentalModel.title,
+        `${field}.mental_model.title`,
+        300,
+      ) as string,
+      summary: boundedString(
+        rawMentalModel.summary,
+        `${field}.mental_model.summary`,
+        3000,
+        false,
+      ),
+      steps: steps.map((step, index) => ({
+        label: boundedString(
+          step.label,
+          `${field}.mental_model.steps[${index}].label`,
+          120,
+        ) as string,
+        title: boundedString(
+          step.title,
+          `${field}.mental_model.steps[${index}].title`,
+          300,
+        ) as string,
+        body: boundedString(
+          step.body,
+          `${field}.mental_model.steps[${index}].body`,
+          3000,
+        ) as string,
+      })),
+    };
+  }
+  return {
+    eyebrow: boundedString(value.eyebrow, `${field}.eyebrow`, 200) as string,
+    headline: boundedString(value.headline, `${field}.headline`, 500) as string,
+    summary: boundedString(value.summary, `${field}.summary`, 3000) as string,
+    contextCards,
+    mentalModel,
+  };
+}
+
+async function readPresentationSidecar(
+  path: string,
+): Promise<ReviewPresentation> {
+  const value = JSON.parse(
+    await readBoundedFile(resolve(path), MAX_REQUIREMENTS_BYTES),
+  ) as unknown;
+  const presentation = normalizePresentation(value);
+  if (!presentation) throw new Error('presentation must be an object');
+  return presentation;
+}
+
 
 function preserveFindingLifecycle(
   fresh: ReviewFinding,
@@ -703,6 +853,10 @@ export async function prepareReview(
         new Set(rawFindings.map((finding) => finding.id)),
       )
     : new Map<string, FindingScenario>();
+  const preparedPresentation = options.presentationPath
+    ? await readPresentationSidecar(options.presentationPath)
+    : undefined;
+
   const findings = rawFindings.map((finding) => {
     const scenario = scenarios.get(finding.id) ?? finding.scenario;
     return {
@@ -781,6 +935,11 @@ export async function prepareReview(
       verdict: currentVerdict(lifecycleFindings),
       intent: artifact.intent,
       primer: buildBusinessPrimer(specification, artifact.intent),
+      presentation:
+        preparedPresentation ??
+        (previousReview?.reviewedCommit === artifact.scope.head_sha
+          ? previousReview.presentation
+          : null),
       findings: lifecycleFindings,
       generatedAt: (options.now ?? new Date()).toISOString(),
     };
@@ -852,8 +1011,19 @@ function currentVerdict(findings: ReviewFinding[]): string {
 function migrateStoredReview(value: unknown): StoredReview {
   if (!isRecord(value) || !Array.isArray(value.findings))
     throw new Error('Invalid stored review');
-  if (value.version === 2) return value as unknown as StoredReview;
+
+  if (value.version === 2) {
+    if (value.presentation !== undefined) {
+      normalizePresentation(value.presentation, 'review.presentation');
+      return value as unknown as StoredReview;
+    }
+    return {
+      ...(value as unknown as StoredReview),
+      presentation: null,
+    };
+  }
   if (value.version !== 1) throw new Error('Unsupported stored review version');
+
   const originalVerdict = boundedString(value.verdict, 'review.verdict', 200) as string;
   const findings = value.findings.map((rawFinding, index) => {
     const scenario = storedScenario(rawFinding.scenario, `review.findings[${index}].scenario`);
@@ -896,6 +1066,8 @@ function migrateStoredReview(value: unknown): StoredReview {
     version: 2,
     originalVerdict,
     verdict: currentVerdict(findings),
+    presentation: normalizePresentation(value.presentation, 'review.presentation'),
+
     findings,
   };
 }
@@ -1118,167 +1290,550 @@ export function renderReviewPage(review: StoredReview): string {
 <meta name="referrer" content="no-referrer">
 <title>${htmlEscape(review.title)} - Interactive review</title>
 <style>
-:root { color-scheme: light; font-family: Inter, ui-sans-serif, system-ui, sans-serif; color: #172033; background: #f6f8fc; }
-* { box-sizing: border-box; } body { margin: 0; } a { color: #164ea6; } button, input, textarea { font: inherit; }
-header { background: #13233f; color: #fff; padding: 1.25rem max(1rem, calc((100vw - 1200px) / 2)); } header p { margin: .35rem 0 0; color: #d8e4fa; overflow-wrap: anywhere; }
-.shell { width: min(1200px, calc(100% - 2rem)); min-width: 0; margin: 1.25rem auto 3rem; } .panel, article { min-width: 0; background: #fff; border: 1px solid #d9e0eb; border-radius: .75rem; box-shadow: 0 1px 2px #13233f0d; }
-.panel { padding: 1.25rem; margin-bottom: 1rem; } h1,h2,h3 { margin-top: 0; overflow-wrap: anywhere; } h2 { font-size: 1.2rem; } h3 { font-size: 1rem; margin-bottom: .35rem; } p, li, label, strong, .meta, .gap { overflow-wrap: anywhere; word-break: break-word; }
-.context-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: .8rem; } .context-item { min-width: 0; border-left: 3px solid #8aa9d6; padding-left: .7rem; } .context-item pre { white-space: pre-wrap; overflow-wrap: anywhere; } .gap { color: #7a2b17; font-style: italic; }
-.controls { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: .75rem; align-items: center; } .filters { display: flex; flex-wrap: wrap; gap: .4rem; } button { cursor: pointer; border: 1px solid #9aa9bd; border-radius: .35rem; background: #fff; padding: .4rem .65rem; } button[aria-pressed="true"] { background: #164ea6; color: #fff; border-color: #164ea6; }
-input, textarea { width: 100%; min-width: 0; border: 1px solid #9aa9bd; border-radius: .35rem; padding: .55rem; } textarea { min-height: 5rem; resize: vertical; } #findings { display: grid; min-width: 0; gap: 1rem; }
-.finding { min-width: 0; padding: 1.2rem; } .finding-top, .finding-top > *, .excerpt-grid, .excerpt-grid > * { min-width: 0; } .finding-top { display: flex; align-items: flex-start; gap: .7rem; justify-content: space-between; } .tag { display: inline-block; border-radius: 999px; padding: .15rem .5rem; font-weight: 700; font-size: .78rem; background: #e8edf5; } .P0 { background: #ffe1df; color: #912018; } .P1 { background: #ffefd6; color: #824300; } .P2 { background: #e7f0ff; color: #164ea6; } .P3 { background: #edf0f4; color: #4c596d; } .active { background: #ffe1df; color: #912018; } .question { background: #e7f0ff; color: #164ea6; } .withdrawn { background: #edf0f4; color: #4c596d; }
-.meta { color: #536176; font-size: .9rem; } pre { max-width: 100%; min-width: 0; overflow-x: auto; white-space: pre; padding: .8rem; background: #101928; color: #e8eef8; border-radius: .35rem; font-size: .82rem; } .excerpt-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: .75rem; }
-.comment { margin-top: .65rem; padding: .7rem; border-left: 3px solid #c5d0e0; background: #f8fafc; } .assistant { border-left-color: #38966a; } .comment p { white-space: pre-wrap; } .reply-form { margin-top: .6rem; }
-.hidden { display: none; } .empty { color: #536176; } .small { font-size: .85rem; } .warning { color: #7a2b17; }
-@media (max-width: 720px) { .shell { width: calc(100% - 1rem); margin-top: .5rem; } .context-grid, .excerpt-grid, .controls { grid-template-columns: 1fr; } .finding-top { display: block; } .finding-top .tag { margin-top: .5rem; } }
+:root {
+  color-scheme: light;
+  --ink: #111a2c;
+  --muted: #5d6678;
+  --paper: #f4f7fb;
+  --panel: #ffffff;
+  --line: #d7dfeb;
+  --blue: #2159d1;
+  --blue-dark: #0b3fa5;
+  --blue-soft: #eef4ff;
+  --red: #b52f36;
+  --red-soft: #fff0f1;
+  --amber: #8a5b00;
+  --amber-soft: #fff7df;
+  --green: #177455;
+  --green-soft: #eaf8f2;
+  --code: #0d1424;
+  --code-text: #dbe7ff;
+  --shadow: 0 18px 50px rgba(33, 51, 87, .1);
+  --radius: 14px;
+  font-family: "Segoe UI", Aptos, system-ui, sans-serif;
+  color: var(--ink);
+  background: var(--paper);
+}
+* { box-sizing: border-box; }
+html { scroll-behavior: smooth; scroll-padding-top: 24px; }
+body { margin: 0; min-width: 0; background: var(--paper); font-size: 15px; line-height: 1.58; }
+button, input, textarea { font: inherit; }
+button, summary, a { -webkit-tap-highlight-color: transparent; }
+a { color: var(--blue); }
+a:focus-visible, button:focus-visible, input:focus-visible, textarea:focus-visible, summary:focus-visible { outline: 3px solid #8bb6ff; outline-offset: 2px; }
+h1, h2, h3, h4, p, li, label, strong, .meta, .gap, .rail-link-label { overflow-wrap: anywhere; word-break: break-word; }
+.skip-link { position: fixed; left: 12px; top: -64px; z-index: 100; padding: 10px 14px; border-radius: 8px; background: var(--ink); color: #fff; }
+.skip-link:focus { top: 12px; }
+.review-shell { display: grid; grid-template-columns: 288px minmax(0, 1fr); min-height: 100vh; }
+.review-rail { position: sticky; top: 0; height: 100vh; overflow-y: auto; padding: 28px 20px; border-right: 1px solid #27334b; background: var(--ink); color: #e8eef9; }
+.rail-brand { display: flex; gap: 12px; align-items: center; margin-bottom: 24px; }
+.rail-mark { display: grid; place-items: center; width: 42px; height: 42px; flex: 0 0 auto; border: 1px solid #50607c; border-radius: 9px; color: #fff; font: 750 13px/1 "Cascadia Code", Consolas, monospace; letter-spacing: .06em; }
+.rail-brand strong, .rail-brand span { display: block; }
+.rail-brand strong { color: #fff; font-size: 14px; }
+.rail-brand span { color: #9eacc3; font-size: 12px; }
+.rail-verdict { padding: 16px; border: 1px solid #34425d; border-radius: 10px; background: #17243b; }
+.rail-verdict b { display: block; margin-bottom: 7px; color: #9eacc3; font: 750 10px/1.2 "Cascadia Code", Consolas, monospace; letter-spacing: .1em; text-transform: uppercase; }
+.rail-verdict strong { display: block; color: #fff; font-size: 16px; line-height: 1.3; }
+.rail-verdict span { display: block; margin-top: 7px; color: #b9c5d8; font-size: 12px; }
+.rail-label { margin: 24px 8px 8px; color: #7f8da6; font: 750 10px/1.2 "Cascadia Code", Consolas, monospace; letter-spacing: .11em; text-transform: uppercase; }
+.rail-nav { display: grid; gap: 4px; }
+.rail-nav a { display: grid; grid-template-columns: 28px minmax(0, 1fr) auto; gap: 8px; align-items: center; min-width: 0; padding: 8px; border-radius: 7px; color: #c9d3e3; text-decoration: none; font-size: 12px; }
+.rail-nav a:hover, .rail-nav a.active { background: #22314c; color: #fff; }
+.rail-index { color: #7f8da6; font: 700 10px/1 "Cascadia Code", Consolas, monospace; }
+.rail-state { width: 8px; height: 8px; border-radius: 50%; background: #7f8da6; }
+.rail-state.active { background: #ff7b82; }
+.rail-state.question { background: #f5bd51; }
+.rail-state.withdrawn { background: #8190a8; }
+.rail-note { margin-top: 22px; padding: 12px; border-top: 1px solid #34425d; color: #9eacc3; font-size: 11px; }
+.review-content { min-width: 0; }
+.hero { padding: 68px clamp(24px, 6vw, 84px) 42px; border-bottom: 1px solid var(--line); background: radial-gradient(circle at 92% 8%, #dceaff 0, transparent 28%), linear-gradient(145deg, #fff 0%, #f7faff 68%, #eef4ff 100%); }
+.eyebrow, .section-kicker { margin: 0 0 12px; color: var(--blue); font: 750 11px/1.2 "Cascadia Code", Consolas, monospace; letter-spacing: .11em; text-transform: uppercase; }
+.hero h1 { max-width: 920px; margin: 0; font: 760 clamp(40px, 6vw, 76px)/.98 "Aptos Display", "Segoe UI Variable Display", "Segoe UI", sans-serif; letter-spacing: -.045em; }
+.hero-lede { max-width: 840px; margin: 24px 0 0; color: #3d4960; font-size: clamp(17px, 2vw, 21px); line-height: 1.55; }
+.hero-metrics { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 1px; max-width: 840px; margin-top: 32px; overflow: hidden; border: 1px solid var(--line); border-radius: 11px; background: var(--line); }
+.metric { min-width: 0; padding: 16px 18px; background: rgba(255,255,255,.9); }
+.metric b { display: block; font: 760 25px/1 "Aptos Display", "Segoe UI", sans-serif; }
+.metric span { display: block; margin-top: 6px; color: var(--muted); font-size: 11px; }
+.hero-actions { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 22px; }
+.primary-link { display: inline-flex; gap: 7px; align-items: center; padding: 9px 13px; border: 1px solid #b8cdf5; border-radius: 8px; background: #fff; color: var(--blue-dark); font-weight: 700; text-decoration: none; }
+.primary-link:hover { border-color: var(--blue); }
+.review-main { width: min(1100px, calc(100% - 48px)); margin: 0 auto; padding: 48px 0 72px; }
+.review-section { margin-bottom: 44px; }
+.section-head { display: flex; gap: 20px; align-items: end; justify-content: space-between; margin-bottom: 18px; }
+.section-head h2 { margin: 0; font: 740 clamp(28px, 4vw, 42px)/1.08 "Aptos Display", "Segoe UI", sans-serif; letter-spacing: -.025em; }
+.section-summary { max-width: 780px; margin: 0 0 20px; color: #3d4960; font-size: 16px; }
+.context-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 14px; }
+.context-card { min-width: 0; padding: 20px; border: 1px solid var(--line); border-top: 4px solid #8aa9d6; border-radius: 12px; background: var(--panel); box-shadow: 0 6px 22px rgba(33,51,87,.05); }
+.context-card.problem { border-top-color: var(--red); }
+.context-card.outcome { border-top-color: var(--green); }
+.context-card b { display: block; margin-bottom: 7px; color: var(--blue); font: 750 10px/1.2 "Cascadia Code", Consolas, monospace; letter-spacing: .08em; text-transform: uppercase; }
+.context-card h3 { margin: 0 0 8px; font-size: 18px; line-height: 1.2; }
+.context-card p { margin: 0; color: #3d4960; }
+.context-extras { display: grid; gap: 10px; margin-top: 14px; }
+.model-grid { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 12px; }
+.model-step { position: relative; min-width: 0; padding: 18px; border: 1px solid var(--line); border-radius: 11px; background: #fff; }
+.model-step b { display: block; margin-bottom: 10px; color: var(--blue); font: 750 10px/1.2 "Cascadia Code", Consolas, monospace; letter-spacing: .08em; text-transform: uppercase; }
+.model-step h3 { margin: 0 0 8px; font-size: 17px; line-height: 1.2; }
+.model-step p { margin: 0; color: #465269; font-size: 13px; }
+
+.disclosure { min-width: 0; border: 1px solid var(--line); border-radius: 10px; background: var(--panel); }
+.disclosure summary { display: flex; gap: 12px; align-items: center; justify-content: space-between; min-width: 0; padding: 12px 15px; cursor: pointer; color: #26344d; font-weight: 700; list-style: none; }
+.disclosure summary::-webkit-details-marker { display: none; }
+.disclosure summary::after { content: "+"; flex: 0 0 auto; color: var(--blue); font: 700 18px/1 "Cascadia Code", Consolas, monospace; }
+.disclosure[open] summary::after { content: "−"; }
+.disclosure[open] summary { border-bottom: 1px solid var(--line); }
+.disclosure-body { min-width: 0; padding: 15px; }
+.disclosure-body > :first-child { margin-top: 0; }
+.disclosure-body > :last-child { margin-bottom: 0; }
+.requirements { max-height: 420px; overflow: auto; white-space: pre-wrap; color: #354258; background: #f8fafd; }
+.review-controls { position: sticky; top: 12px; z-index: 10; display: grid; gap: 12px; margin-bottom: 20px; padding: 14px; border: 1px solid var(--line); border-radius: 12px; background: rgba(255,255,255,.96); box-shadow: 0 10px 30px rgba(33,51,87,.1); backdrop-filter: blur(10px); }
+.control-row { display: grid; grid-template-columns: minmax(220px, 1fr) auto; gap: 12px; align-items: center; }
+.filters { display: flex; flex-wrap: wrap; gap: 6px; }
+input, textarea { width: 100%; min-width: 0; border: 1px solid #aab6c8; border-radius: 8px; background: #fff; color: var(--ink); }
+input { padding: 9px 11px; }
+textarea { min-height: 86px; padding: 10px 11px; resize: vertical; }
+button { cursor: pointer; border: 1px solid #aab6c8; border-radius: 7px; background: #fff; color: #27344c; padding: 7px 10px; }
+button:hover { border-color: var(--blue); }
+button[aria-pressed="true"], .comment-form button { border-color: var(--blue); background: var(--blue); color: #fff; }
+#findings { display: grid; min-width: 0; gap: 16px; }
+.finding-group { display: grid; min-width: 0; gap: 14px; }
+.finding-group + .finding-group { margin-top: 24px; }
+.group-title { margin: 0; color: #33415a; font: 740 22px/1.2 "Aptos Display", "Segoe UI", sans-serif; }
+.finding { min-width: 0; overflow: hidden; border: 1px solid var(--line); border-radius: var(--radius); background: var(--panel); box-shadow: var(--shadow); }
+.finding.active { border-color: #e8c5c8; }
+.finding.question { border-color: #ead79f; }
+.finding.withdrawn { border-color: #cfd7e3; }
+.finding-header { display: grid; grid-template-columns: 48px minmax(0, 1fr) auto; gap: 14px; align-items: start; padding: 20px 22px 16px; border-bottom: 1px solid var(--line); }
+.finding-number { display: grid; place-items: center; width: 42px; height: 42px; border: 1px solid #c9d4e5; border-radius: 9px; background: var(--blue-soft); color: var(--blue-dark); font: 750 12px/1 "Cascadia Code", Consolas, monospace; }
+.finding-title { min-width: 0; }
+.finding-title h3 { margin: 0 0 5px; font: 730 clamp(19px, 2.5vw, 25px)/1.18 "Aptos Display", "Segoe UI", sans-serif; }
+.finding-location { display: inline-flex; color: var(--blue); font-size: 12px; font-weight: 650; text-decoration: none; }
+.finding-location:hover { text-decoration: underline; }
+.tags { display: flex; flex-wrap: wrap; gap: 5px; justify-content: flex-end; }
+.tag { display: inline-flex; align-items: center; min-height: 24px; border-radius: 999px; padding: 3px 8px; font: 750 10px/1 "Cascadia Code", Consolas, monospace; letter-spacing: .04em; text-transform: uppercase; }
+.tag.P0, .tag.P1, .tag.active { background: var(--red-soft); color: var(--red); }
+.tag.P2, .tag.question { background: var(--amber-soft); color: var(--amber); }
+.tag.P3, .tag.withdrawn { background: #edf0f4; color: #4c596d; }
+.finding-body { display: grid; gap: 15px; min-width: 0; padding: 20px 22px 22px; }
+.scenario-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 12px; }
+.scenario-card { min-width: 0; padding: 16px; border: 1px solid var(--line); border-radius: 10px; }
+.scenario-card.actual { border-color: #efc7ca; background: var(--red-soft); }
+.scenario-card.expected { border-color: #b9ddcf; background: var(--green-soft); }
+.scenario-card b { display: block; margin-bottom: 7px; font: 750 10px/1.2 "Cascadia Code", Consolas, monospace; letter-spacing: .08em; text-transform: uppercase; }
+.scenario-card.actual b { color: var(--red); }
+.scenario-card.expected b { color: var(--green); }
+.scenario-card p { margin: 0; color: #344158; }
+.provenance { margin: 11px 0 0; padding: 10px 0 0 18px; border-top: 1px solid rgba(181,47,54,.18); color: #5a4850; font-size: 12px; }
+.action-card { display: grid; grid-template-columns: 108px minmax(0, 1fr); gap: 14px; padding: 15px 16px; border-left: 4px solid var(--blue); border-radius: 8px; background: var(--blue-soft); }
+.action-card b { color: var(--blue-dark); font: 750 10px/1.2 "Cascadia Code", Consolas, monospace; letter-spacing: .08em; text-transform: uppercase; }
+.action-card p { margin: 0; }
+.finding-meta { display: flex; flex-wrap: wrap; gap: 8px 18px; color: var(--muted); font-size: 12px; }
+.evidence-list, .history-list { margin: 0; padding-left: 20px; }
+.evidence-list li + li, .history-list li + li { margin-top: 8px; }
+.excerpt-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 12px; min-width: 0; }
+.excerpt-grid > * { min-width: 0; }
+.excerpt-grid h4 { margin: 0 0 7px; font-size: 12px; }
+pre { max-width: 100%; min-width: 0; margin: 0; overflow-x: auto; white-space: pre; border-radius: 8px; padding: 14px; background: var(--code); color: var(--code-text); font: 12px/1.55 "Cascadia Code", Consolas, monospace; }
+.gap { color: #7a2b17; font-style: italic; }
+.discussion-disclosure { background: #fbfcfe; }
+.comment-form { display: grid; grid-template-columns: minmax(0, 1fr) 180px auto; gap: 8px; align-items: end; }
+.comment-form h4 { grid-column: 1 / -1; margin: 0; }
+.comment-form label { color: var(--muted); font-size: 12px; }
+.comment-form button { min-height: 38px; }
+.comment-list { display: grid; gap: 9px; margin-top: 12px; }
+.comment { min-width: 0; padding: 12px; border-left: 3px solid #c5d0e0; border-radius: 0 8px 8px 0; background: #f7f9fc; }
+.comment.assistant { margin: 10px 0 0 12px; border-left-color: var(--green); background: #f0faf6; }
+.comment p { margin: 6px 0 0; white-space: pre-wrap; }
+.comment strong { font-size: 12px; }
+.discussion-panel { padding: 22px; border: 1px solid var(--line); border-radius: var(--radius); background: #fff; box-shadow: var(--shadow); }
+.empty { color: var(--muted); }
+.small { font-size: 12px; }
+.hidden { display: none !important; }
+.toast { position: fixed; right: 20px; bottom: 20px; z-index: 100; max-width: min(360px, calc(100% - 40px)); padding: 11px 14px; border-radius: 8px; background: var(--ink); color: #fff; opacity: 0; transform: translateY(8px); pointer-events: none; transition: opacity .16s ease, transform .16s ease; }
+.toast.show { opacity: 1; transform: translateY(0); }
+@media (max-width: 900px) {
+  .review-shell { display: block; }
+  .review-rail { position: relative; height: auto; padding: 18px; }
+  .rail-brand, .rail-verdict { max-width: 620px; }
+  .rail-label { margin-top: 14px; }
+  .rail-nav { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .rail-note { display: none; }
+  .hero { padding-top: 42px; }
+  .review-controls { position: static; }
+}
+@media (max-width: 720px) {
+  .hero-metrics { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .context-grid, .model-grid, .scenario-grid, .excerpt-grid { grid-template-columns: 1fr; }
+
+  .control-row { grid-template-columns: 1fr; }
+  .finding-header { grid-template-columns: 42px minmax(0, 1fr); padding: 17px; }
+  .tags { grid-column: 2; justify-content: flex-start; }
+  .finding-body { padding: 17px; }
+  .comment-form { grid-template-columns: 1fr; }
+  .comment-form h4 { grid-column: auto; }
+  .comment-form button { justify-self: start; }
+}
+@media (max-width: 520px) {
+  .rail-nav { grid-template-columns: 1fr; }
+  .hero { padding: 34px 18px 30px; }
+  .hero h1 { font-size: 38px; }
+  .review-main { width: min(100% - 24px, 1100px); padding-top: 32px; }
+  .hero-metrics { grid-template-columns: 1fr 1fr; }
+  .metric { padding: 13px; }
+  .action-card { grid-template-columns: 1fr; gap: 5px; }
+}
+@media (prefers-reduced-motion: reduce) {
+  html { scroll-behavior: auto; }
+  .toast { transition: none; }
+}
 </style>
 </head>
 <body>
-<header><strong>Interactive PR review</strong><p id="review-summary">Loading structured review...</p></header>
-<main class="shell">
-<section id="business-context" class="panel" aria-labelledby="business-context-title"><h1 id="business-context-title">Business context</h1><p class="small">Context precedes architecture and findings. Missing evidence is explicit.</p><div id="primer" class="context-grid"></div></section>
-<section class="panel" aria-labelledby="review-controls-title"><h2 id="review-controls-title">Findings</h2><div class="controls"><input id="search" type="search" placeholder="Search findings, files, or reviewers" aria-label="Search findings"><nav class="filters" aria-label="Severity filters"><button type="button" data-severity="all" aria-pressed="true">All severities</button><button type="button" data-severity="P0" aria-pressed="false">P0</button><button type="button" data-severity="P1" aria-pressed="false">P1</button><button type="button" data-severity="P2" aria-pressed="false">P2</button><button type="button" data-severity="P3" aria-pressed="false">P3</button></nav></div><nav class="filters" aria-label="Finding status filters"><button type="button" data-status="all" aria-pressed="true">All statuses</button><button type="button" data-status="active" aria-pressed="false">Active findings</button><button type="button" data-status="question" aria-pressed="false">Open questions</button><button type="button" data-status="withdrawn" aria-pressed="false">Withdrawn</button></nav></section>
-<section id="findings" aria-live="polite"></section>
-<section class="panel" aria-labelledby="general-comments-title"><h2 id="general-comments-title">General comments</h2><form data-comment-form="general"><label>Comment <textarea name="body" required maxlength="${MAX_COMMENT_LENGTH}"></textarea></label><label class="small">Name (optional) <input name="author" maxlength="120"></label><button type="submit">Save local comment</button></form><div id="general-comments"></div></section>
-</main>
+<a class="skip-link" href="#findings-section">Skip to findings</a>
+<div class="review-shell">
+  <aside class="review-rail" aria-label="Review navigation">
+    <div class="rail-brand"><div class="rail-mark">PR</div><div><strong id="rail-repository">Interactive review</strong><span id="rail-pr"></span></div></div>
+    <div class="rail-verdict"><b>Current verdict</b><strong id="rail-verdict">Loading review…</strong><span id="rail-counts"></span></div>
+    <div class="rail-label">Review map</div>
+    <nav class="rail-nav" id="review-nav"><a href="#overview"><span class="rail-index">00</span><span class="rail-link-label">Overview</span></a><a href="#business-context"><span class="rail-index">01</span><span class="rail-link-label">Business context</span></a><a class="hidden" id="mental-model-nav" href="#mental-model"><span class="rail-index">02</span><span class="rail-link-label">Mental model</span></a><a href="#findings-section"><span class="rail-index">03</span><span class="rail-link-label">Findings</span></a></nav>
+
+    <div class="rail-label">Findings</div>
+    <nav class="rail-nav" id="finding-nav"></nav>
+    <div class="rail-label">Discuss</div>
+    <nav class="rail-nav"><a href="#discussion"><span class="rail-index">+</span><span class="rail-link-label">General comments</span></a></nav>
+    <p class="rail-note">Comments stay on this workstation. Heavy evidence and code remain collapsed until requested.</p>
+  </aside>
+  <div class="review-content">
+    <header class="hero" id="overview">
+      <p class="eyebrow" id="review-eyebrow">Structured pull request review</p>
+      <h1 id="review-title">Loading review…</h1>
+      <p class="hero-lede" id="review-summary"></p>
+      <div class="hero-metrics" id="review-metrics" aria-label="Review summary metrics"></div>
+      <div class="hero-actions" id="review-actions"></div>
+    </header>
+    <main class="review-main" id="main">
+      <section class="review-section" id="business-context" aria-labelledby="business-context-title">
+        <div class="section-head"><div><p class="section-kicker">Business primer</p><h2 id="business-context-title">Understand the change first</h2></div></div>
+        <p class="section-summary">The operational context stays ahead of implementation detail. Missing context is explicit but does not dominate the review.</p>
+        <div class="context-grid" id="primer"></div>
+        <div class="context-extras" id="primer-extras"></div>
+      </section>
+      <section class="review-section hidden" id="mental-model" aria-labelledby="mental-model-title">
+        <div class="section-head"><div><p class="section-kicker">Mental model</p><h2 id="mental-model-title"></h2></div></div>
+        <p class="section-summary" id="mental-model-summary"></p>
+        <div class="model-grid" id="mental-model-steps"></div>
+      </section>
+
+      <section class="review-section" id="findings-section" aria-labelledby="review-controls-title">
+        <div class="section-head"><div><p class="section-kicker">Review findings</p><h2 id="review-controls-title">Inspect the failure path</h2></div></div>
+        <div class="review-controls">
+          <div class="control-row"><input id="search" type="search" placeholder="Search title, file, impact, or reviewer" aria-label="Search findings"><nav class="filters" aria-label="Severity filters"><button type="button" data-severity="all" aria-pressed="true">All severities</button><button type="button" data-severity="P0" aria-pressed="false">P0</button><button type="button" data-severity="P1" aria-pressed="false">P1</button><button type="button" data-severity="P2" aria-pressed="false">P2</button><button type="button" data-severity="P3" aria-pressed="false">P3</button></nav></div>
+          <nav class="filters" aria-label="Finding status filters"><button type="button" data-status="all" aria-pressed="true">All statuses</button><button type="button" data-status="active" aria-pressed="false">Active findings</button><button type="button" data-status="question" aria-pressed="false">Open questions</button><button type="button" data-status="withdrawn" aria-pressed="false">Withdrawn</button></nav>
+        </div>
+        <div id="findings" aria-live="polite"></div>
+      </section>
+      <section class="review-section" id="discussion" aria-labelledby="general-comments-title">
+        <div class="section-head"><div><p class="section-kicker">Discussion</p><h2 id="general-comments-title">General comments</h2></div></div>
+        <div class="discussion-panel"><form class="comment-form" data-comment-form="general"><h4>Add a general comment</h4><label>Comment<textarea name="body" required maxlength="${MAX_COMMENT_LENGTH}"></textarea></label><label>Name (optional)<input name="author" maxlength="120"></label><button type="submit">Save comment</button></form><div id="general-comments" class="comment-list"></div></div>
+      </section>
+    </main>
+  </div>
+</div>
+<div class="toast" id="toast" role="status" aria-live="polite"></div>
 <script>
 (() => {
-  const state = { review: null, comments: [], severity: 'all', status: 'all', search: '' };
-  const primerLabels = [['whoConfigures', 'Who configures this?'], ['operationalProblem', 'Operational problem'], ['intendedOutcome', 'Intended before/after outcome'], ['businessImportance', 'Why the business cares'], ['successCriteria', 'Success criteria'], ['scope', 'Scope'], ['nonGoals', 'Non-goals']];
+  const state = { review: null, comments: [], severity: 'all', status: 'all', search: '', observer: null };
+  const primerLabels = [['whoConfigures', 'Who configures this?', 'Operator', 'neutral'], ['operationalProblem', 'Operational problem', 'Problem', 'problem'], ['intendedOutcome', 'Intended before / after', 'Outcome', 'outcome'], ['businessImportance', 'Why the business cares', 'Business value', 'neutral'], ['successCriteria', 'Success criteria', 'Success', 'outcome'], ['scope', 'Scope', 'In scope', 'neutral'], ['nonGoals', 'Non-goals', 'Boundary', 'neutral']];
+  const statusLabels = { active: 'Active findings', question: 'Open questions', withdrawn: 'Withdrawn findings' };
   const el = (tag, text, className) => { const node = document.createElement(tag); if (text !== undefined && text !== null) node.textContent = String(text); if (className) node.className = className; return node; };
   const request = async (path, options) => { const response = await fetch(path, options); if (!response.ok) throw new Error(await response.text()); return response.json(); };
+  function toast(message) { const node = document.querySelector('#toast'); node.textContent = message; node.classList.add('show'); clearTimeout(toast.timer); toast.timer = setTimeout(() => node.classList.remove('show'), 2400); }
+  function disclosure(title, content, className) {
+    const details = el('details', undefined, 'disclosure' + (className ? ' ' + className : ''));
+    details.append(el('summary', title));
+    const body = el('div', undefined, 'disclosure-body');
+    if (Array.isArray(content)) body.append(...content); else body.append(content);
+    details.append(body);
+    return details;
+  }
+  function renderHero() {
+    const review = state.review;
+    const counts = review.findings.reduce((total, finding) => { total[finding.status] += 1; return total; }, { active: 0, question: 0, withdrawn: 0 });
+    const files = new Set(review.findings.map((finding) => finding.file)).size;
+    document.querySelector('#rail-repository').textContent = review.repository;
+    document.querySelector('#rail-pr').textContent = 'Pull request #' + review.prNumber;
+    document.querySelector('#rail-verdict').textContent = review.verdict;
+    document.querySelector('#rail-counts').textContent = counts.active + ' active · ' + counts.question + ' questions · ' + counts.withdrawn + ' withdrawn';
+    const presentation = review.presentation;
+    document.querySelector('#review-eyebrow').textContent = presentation?.eyebrow || review.repository + ' / PR #' + review.prNumber;
+    document.querySelector('#review-title').textContent = presentation?.headline || review.title;
+    document.querySelector('#review-summary').textContent = presentation?.summary || review.intent;
+
+    const metrics = document.querySelector('#review-metrics');
+    metrics.replaceChildren();
+    for (const [value, label] of [[counts.active, 'active findings'], [counts.question, 'open questions'], [counts.withdrawn, 'withdrawn'], [files, 'files with findings']]) {
+      const metric = el('div', undefined, 'metric');
+      metric.append(el('b', value), el('span', label));
+      metrics.append(metric);
+    }
+    const actions = document.querySelector('#review-actions');
+    actions.replaceChildren();
+    if (review.githubRepository) {
+      const link = el('a', 'Open PR #' + review.prNumber + ' on GitHub ↗', 'primary-link');
+      link.href = 'https://github.com/' + review.githubRepository + '/pull/' + review.prNumber;
+      link.target = '_blank';
+      link.rel = 'noopener noreferrer';
+      actions.append(link);
+    }
+    actions.append(el('span', 'Reviewed commit ' + review.reviewedCommit.slice(0, 8), 'small meta'));
+  }
   function renderPrimer() {
     const root = document.querySelector('#primer');
+    const extras = document.querySelector('#primer-extras');
     root.replaceChildren();
-    for (const [key, label] of primerLabels) {
-      const item = el('div', undefined, 'context-item');
-      item.append(el('h3', label));
-      const field = state.review.primer[key];
-      item.append(el('p', field.value || field.evidenceGap, field.value ? '' : 'gap'));
-      root.append(item);
+    extras.replaceChildren();
+    const gaps = [];
+    const presentationCards = state.review.presentation?.contextCards || [];
+    if (presentationCards.length) {
+      for (const item of presentationCards) {
+        const card = el('article', undefined, 'context-card ' + item.tone);
+        card.append(el('b', item.label), el('h3', item.title), el('p', item.body));
+        root.append(card);
+      }
+      for (const [key, title] of primerLabels) {
+        const field = state.review.primer[key];
+        if (!field.value) gaps.push(title + ': ' + field.evidenceGap);
+      }
+    } else {
+      let values = 0;
+      for (const [key, title, label, tone] of primerLabels) {
+        const field = state.review.primer[key];
+        if (!field.value) { gaps.push(title + ': ' + field.evidenceGap); continue; }
+        values += 1;
+        const card = el('article', undefined, 'context-card ' + tone);
+        card.append(el('b', label), el('h3', title), el('p', field.value));
+        root.append(card);
+      }
+      if (!values) {
+        const card = el('article', undefined, 'context-card');
+        card.append(el('b', 'Review intent'), el('h3', 'What this change is trying to do'), el('p', state.review.intent));
+        root.append(card);
+      }
+    }
+
+    if (gaps.length) {
+      const list = el('ul', undefined, 'evidence-list');
+      for (const gap of gaps) list.append(el('li', gap, 'gap'));
+      extras.append(disclosure('Missing business context (' + gaps.length + ')', list));
     }
     if (state.review.primer.providedRequirements) {
-      const requirements = el('div', undefined, 'context-item');
-      requirements.append(el('h3', 'Supplied requirements'), el('pre', state.review.primer.providedRequirements));
-      root.append(requirements);
+      extras.append(disclosure('Supplied requirements', el('pre', state.review.primer.providedRequirements, 'requirements')));
     }
   }
-  function commentForm(findingId) { const form = el('form'); form.dataset.commentForm = findingId || 'general'; const area = document.createElement('textarea'); area.name = 'body'; area.required = true; area.maxLength = ${MAX_COMMENT_LENGTH}; area.setAttribute('aria-label', findingId ? 'Comment on ' + findingId : 'General comment'); const author = document.createElement('input'); author.name = 'author'; author.maxLength = 120; author.placeholder = 'Name (optional)'; const submit = el('button', 'Save local comment'); submit.type = 'submit'; form.append(el('h3', findingId ? 'Comment on ' + findingId : 'General comment'), area, author, submit); return form; }
+  function renderMentalModel() {
+    const section = document.querySelector('#mental-model');
+    const nav = document.querySelector('#mental-model-nav');
+    const model = state.review.presentation?.mentalModel;
+    section.classList.toggle('hidden', !model);
+    nav.classList.toggle('hidden', !model);
+    if (!model) return;
+    document.querySelector('#mental-model-title').textContent = model.title;
+    const summary = document.querySelector('#mental-model-summary');
+    summary.textContent = model.summary || '';
+    summary.classList.toggle('hidden', !model.summary);
+    const root = document.querySelector('#mental-model-steps');
+    root.replaceChildren();
+    for (const step of model.steps) {
+      const card = el('article', undefined, 'model-step');
+      card.append(el('b', step.label), el('h3', step.title), el('p', step.body));
+      root.append(card);
+    }
+  }
+
+  function commentForm(findingId) {
+    const form = el('form', undefined, 'comment-form');
+    form.dataset.commentForm = findingId || 'general';
+    form.append(el('h4', findingId ? 'Discuss ' + findingId : 'Add a general comment'));
+    const bodyLabel = el('label', 'Comment');
+    const area = document.createElement('textarea');
+    area.name = 'body';
+    area.required = true;
+    area.maxLength = ${MAX_COMMENT_LENGTH};
+    area.setAttribute('aria-label', findingId ? 'Comment on ' + findingId : 'General comment');
+    bodyLabel.append(area);
+    const authorLabel = el('label', 'Name (optional)');
+    const author = document.createElement('input');
+    author.name = 'author';
+    author.maxLength = 120;
+    authorLabel.append(author);
+    const submit = el('button', 'Save comment');
+    submit.type = 'submit';
+    form.append(bodyLabel, authorLabel, submit);
+    return form;
+  }
   function renderComments(root, findingId) {
     root.replaceChildren();
     const comments = state.comments.filter((comment) => comment.findingId === findingId);
-    if (!comments.length) {
-      root.append(el('p', 'No local comments yet.', 'empty small'));
-      return;
-    }
+    if (!comments.length) { root.append(el('p', 'No local comments yet.', 'empty small')); return; }
     for (const comment of comments) {
       const card = el('div', undefined, 'comment');
-      card.append(el('strong', comment.author + ' - ' + new Date(comment.createdAt).toLocaleString()), el('p', comment.body));
+      card.append(el('strong', comment.author + ' · ' + new Date(comment.createdAt).toLocaleString()), el('p', comment.body));
       for (const reply of comment.replies) {
         const replyCard = el('div', undefined, 'comment assistant');
-        replyCard.append(el('strong', reply.author + ' (assistant) - ' + new Date(reply.createdAt).toLocaleString()), el('p', reply.body));
+        replyCard.append(el('strong', reply.author + ' · assistant · ' + new Date(reply.createdAt).toLocaleString()), el('p', reply.body));
         card.append(replyCard);
       }
       root.append(card);
     }
   }
-  const statusLabels = { active: 'Active findings', question: 'Open questions', withdrawn: 'Withdrawn findings' };
+  function safeSourceLink(finding) {
+    if (typeof finding.sourceLink !== 'string') return null;
+    try {
+      const url = new URL(finding.sourceLink);
+      const lines = url.hash.slice(2).split('-L').map(Number);
+      return url.protocol === 'https:' && url.hostname === 'github.com' && url.pathname.includes('/blob/') && url.hash.startsWith('#L') && Number.isInteger(lines[0]) && Number.isInteger(lines[1]) && lines[0] > 0 && lines[1] >= lines[0] ? url.toString() : null;
+    } catch { return null; }
+  }
   function renderFinding(finding) {
-    const article = el('article', undefined, 'finding');
+    const article = el('article', undefined, 'finding ' + finding.status);
+    article.id = 'finding-' + finding.id.slice(1);
     article.dataset.findingSeverity = finding.severity;
     article.dataset.findingStatus = finding.status;
-    const top = el('div', undefined, 'finding-top');
-    const heading = el('div');
-    heading.append(el('h2', finding.id + ' ' + finding.title), el('p', finding.file + ':' + finding.line + '-' + finding.endLine, 'meta'));
-    const sourceLink = (() => {
-      if (typeof finding.sourceLink !== 'string') return null;
-      try {
-        const url = new URL(finding.sourceLink);
-        const [startLine, endLine] = url.hash.slice(2).split('-L').map(Number);
-        return url.protocol === 'https:' && url.hostname === 'github.com' && url.pathname.includes('/blob/') && url.hash.startsWith('#L') && Number.isInteger(startLine) && Number.isInteger(endLine) && startLine > 0 && endLine >= startLine ? url.toString() : null;
-      } catch { return null; }
-    })();
+    const header = el('header', undefined, 'finding-header');
+    const number = el('div', finding.id, 'finding-number');
+    const title = el('div', undefined, 'finding-title');
+    title.append(el('h3', finding.title));
+    const sourceLink = safeSourceLink(finding);
     if (sourceLink) {
-      const link = el('a', 'Open exact reviewed lines on GitHub');
+      const link = el('a', finding.file + ':' + finding.line + '-' + finding.endLine + ' · Open on GitHub ↗', 'finding-location');
       link.href = sourceLink;
       link.target = '_blank';
       link.rel = 'noopener noreferrer';
-      heading.append(link);
-    }
-    const tags = el('div');
+      title.append(link);
+    } else title.append(el('span', finding.file + ':' + finding.line + '-' + finding.endLine, 'meta'));
+    const tags = el('div', undefined, 'tags');
     tags.append(el('span', finding.severity, 'tag ' + finding.severity), el('span', finding.status, 'tag ' + finding.status));
-    top.append(heading, tags);
-    article.append(top, el('h3', 'What actually happens'));
+    header.append(number, title, tags);
+    const body = el('div', undefined, 'finding-body');
     const scenario = finding.scenario || { actualHappens: null, expectedSuggested: null, actualEvidenceGap: 'Evidence gap: no scenario is available.', expectedEvidenceGap: 'Evidence gap: no expected behavior is available.' };
-    article.append(el('p', scenario.actualHappens || scenario.actualEvidenceGap, scenario.actualHappens ? '' : 'gap'));
+    const scenarioGrid = el('div', undefined, 'scenario-grid');
+    const actual = el('div', undefined, 'scenario-card actual');
+    actual.append(el('b', 'What actually happens'), el('p', scenario.actualHappens || scenario.actualEvidenceGap, scenario.actualHappens ? '' : 'gap'));
     if (scenario.actualHappens) {
-      const evidence = el('ul');
-      evidence.append(el('li', 'Trigger/reachability: ' + scenario.actualTriggerEvidence), el('li', 'Observable outcome: ' + scenario.actualOutcomeEvidence));
-      article.append(el('h3', 'Scenario provenance'), evidence);
+      const provenance = el('ul', undefined, 'provenance');
+      provenance.append(el('li', 'Trigger / reachability: ' + scenario.actualTriggerEvidence), el('li', 'Observable outcome: ' + scenario.actualOutcomeEvidence));
+      actual.append(provenance);
     }
-    article.append(el('h3', 'Expected / suggested'), el('p', scenario.expectedSuggested || scenario.expectedEvidenceGap, scenario.expectedSuggested ? '' : 'gap'));
-    article.append(el('h3', 'Required response'), el('p', finding.requiredResponse), el('p', 'Confidence: ' + finding.confidence + ' | Reviewers: ' + (finding.reviewers.join(', ') || 'not recorded'), 'meta'));
-    if (finding.evidence.length || finding.firstEvidence) {
-      article.append(el('h3', 'Referenced evidence'));
-      const list = el('ul');
-      for (const evidence of [...finding.evidence, ...(finding.firstEvidence ? [finding.firstEvidence] : [])]) list.append(el('li', evidence));
-      article.append(list);
+    const expected = el('div', undefined, 'scenario-card expected');
+    expected.append(el('b', 'Expected / suggested'), el('p', scenario.expectedSuggested || scenario.expectedEvidenceGap, scenario.expectedSuggested ? '' : 'gap'));
+    scenarioGrid.append(actual, expected);
+    body.append(scenarioGrid);
+    const action = el('div', undefined, 'action-card');
+    action.append(el('b', 'Required response'), el('p', finding.requiredResponse));
+    body.append(action);
+    const meta = el('div', undefined, 'finding-meta');
+    meta.append(el('span', 'Confidence ' + finding.confidence), el('span', 'Reviewers ' + (finding.reviewers.join(', ') || 'not recorded')));
+    body.append(meta);
+    const evidenceValues = [...new Set([...finding.evidence, ...(finding.firstEvidence ? [finding.firstEvidence] : [])])];
+    if (evidenceValues.length) {
+      const list = el('ul', undefined, 'evidence-list');
+      for (const evidence of evidenceValues) list.append(el('li', evidence));
+      body.append(disclosure('Referenced evidence (' + evidenceValues.length + ')', list));
     }
     if (finding.revisions.length) {
-      article.append(el('h3', 'Lifecycle history'));
-      const history = el('ul');
+      const history = el('ul', undefined, 'history-list');
       for (const revision of finding.revisions) history.append(el('li', new Date(revision.createdAt).toLocaleString() + ': ' + revision.status + ' — ' + revision.rationale));
-      article.append(history, el('h3', 'Original claim'), el('p', finding.original.title + ' | ' + finding.original.severity));
+      history.append(el('li', 'Original claim: ' + finding.original.title + ' | ' + finding.original.severity));
+      body.append(disclosure('Lifecycle history', history));
     }
     const excerpts = el('div', undefined, 'excerpt-grid');
-    if (finding.excerpts.before) { const before = el('div'); before.append(el('h3', 'Before excerpt'), el('pre', finding.excerpts.before.content)); excerpts.append(before); }
-    if (finding.excerpts.after) { const after = el('div'); after.append(el('h3', 'Reviewed commit excerpt'), el('pre', finding.excerpts.after.content)); excerpts.append(after); }
-    if (excerpts.childElementCount) article.append(el('h3', 'Focused code context'), excerpts);
-    else article.append(el('p', 'Evidence gap: no exact-commit code excerpt was available locally.', 'gap small'));
-    article.append(commentForm(finding.id));
-    const comments = el('div');
+    if (finding.excerpts.before) { const before = el('div'); before.append(el('h4', 'Before excerpt'), el('pre', finding.excerpts.before.content)); excerpts.append(before); }
+    if (finding.excerpts.after) { const after = el('div'); after.append(el('h4', 'Reviewed commit excerpt'), el('pre', finding.excerpts.after.content)); excerpts.append(after); }
+    if (excerpts.childElementCount) body.append(disclosure('Focused code context', excerpts));
+    else body.append(el('p', 'Evidence gap: no exact-commit code excerpt was available locally.', 'gap small'));
+    const discussion = el('div');
+    const comments = el('div', undefined, 'comment-list');
     comments.dataset.commentsFor = finding.id;
-    article.append(comments);
+    discussion.append(commentForm(finding.id), comments);
+    const commentCount = state.comments.filter((comment) => comment.findingId === finding.id).length;
+    const discussionDisclosure = disclosure('Discussion' + (commentCount ? ' (' + commentCount + ')' : ''), discussion, 'discussion-disclosure');
+    if (commentCount) discussionDisclosure.open = true;
+    body.append(discussionDisclosure);
+    article.append(header, body);
     renderComments(comments, finding.id);
     return article;
   }
+  function visibleFindings() {
+    const query = state.search.toLowerCase();
+    return state.review.findings.filter((finding) => (state.severity === 'all' || finding.severity === state.severity) && (state.status === 'all' || finding.status === state.status) && [finding.id, finding.title, finding.file, finding.status, finding.reviewers.join(' '), finding.requiredResponse, finding.scenario.actualHappens || '', finding.scenario.expectedSuggested || '', ...finding.revisions.map((revision) => revision.rationale)].join(' ').toLowerCase().includes(query));
+  }
+  function renderFindingNav(findings) {
+    const nav = document.querySelector('#finding-nav');
+    nav.replaceChildren();
+    for (const finding of findings) {
+      const link = document.createElement('a');
+      link.href = '#finding-' + finding.id.slice(1);
+      link.append(el('span', finding.id, 'rail-index'), el('span', finding.title, 'rail-link-label'), el('span', undefined, 'rail-state ' + finding.status));
+      nav.append(link);
+    }
+  }
+  function observeSections() {
+    if (state.observer) state.observer.disconnect();
+    state.observer = new IntersectionObserver((entries) => {
+      const visible = entries.filter((entry) => entry.isIntersecting).sort((a, b) => b.intersectionRatio - a.intersectionRatio)[0];
+      if (!visible) return;
+      document.querySelectorAll('.rail-nav a').forEach((link) => link.classList.toggle('active', link.getAttribute('href') === '#' + visible.target.id));
+    }, { rootMargin: '-15% 0px -70% 0px', threshold: [0, .2, .5] });
+    document.querySelectorAll('#overview, #business-context, #findings-section, #discussion, article.finding').forEach((node) => state.observer.observe(node));
+  }
   function renderFindings() {
     const root = document.querySelector('#findings');
+    if (state.observer) {
+      state.observer.disconnect();
+      state.observer = null;
+    }
     root.replaceChildren();
-    const query = state.search.toLowerCase();
-    const visible = state.review.findings.filter((finding) => (state.severity === 'all' || finding.severity === state.severity) && (state.status === 'all' || finding.status === state.status) && [finding.id, finding.title, finding.file, finding.status, finding.reviewers.join(' '), finding.requiredResponse, finding.scenario.actualHappens || '', finding.scenario.expectedSuggested || '', ...finding.revisions.map((revision) => revision.rationale)].join(' ').toLowerCase().includes(query));
-    if (!visible.length) { root.append(el('p', 'No findings match the current filters.', 'panel empty')); return; }
+    const visible = visibleFindings();
+    renderFindingNav(visible);
+    if (!visible.length) { root.append(el('p', 'No findings match the current filters.', 'discussion-panel empty')); return; }
     for (const status of ['active', 'question', 'withdrawn']) {
       const group = visible.filter((finding) => finding.status === status);
       if (!group.length) continue;
-      root.append(el('h2', statusLabels[status] + ' (' + group.length + ')'));
-      for (const finding of group) root.append(renderFinding(finding));
+      const section = el('section', undefined, 'finding-group');
+      section.append(el('h3', statusLabels[status] + ' (' + group.length + ')', 'group-title'));
+      for (const finding of group) section.append(renderFinding(finding));
+      root.append(section);
     }
+    observeSections();
   }
-  function render() { const counts = state.review.findings.reduce((total, finding) => ({ ...total, [finding.status]: total[finding.status] + 1 }), { active: 0, question: 0, withdrawn: 0 }); document.querySelector('#review-summary').textContent = state.review.title + ' | ' + state.review.verdict + ' | active: ' + counts.active + ', open questions: ' + counts.question + ', withdrawn: ' + counts.withdrawn + ' | reviewed commit ' + state.review.reviewedCommit; renderPrimer(); renderFindings(); renderComments(document.querySelector('#general-comments'), null); }
+  function render() {
+    renderHero();
+    renderPrimer();
+    renderMentalModel();
+    renderFindings();
+    renderComments(document.querySelector('#general-comments'), null);
+  }
   async function refreshComments() { state.comments = (await request('/api/comments')).comments; }
   document.addEventListener('submit', async (event) => {
     const form = event.target;
     if (!(form instanceof HTMLFormElement) || !form.dataset.commentForm) return;
     event.preventDefault();
     const data = new FormData(form);
+    const button = form.querySelector('button');
+    button.disabled = true;
     try {
-      await request('/api/comments', {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ body: data.get('body'), author: data.get('author'), findingId: form.dataset.commentForm === 'general' ? null : form.dataset.commentForm }),
-      });
+      await request('/api/comments', { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ body: data.get('body'), author: data.get('author'), findingId: form.dataset.commentForm === 'general' ? null : form.dataset.commentForm }) });
       form.reset();
       await refreshComments();
       render();
-    } catch (error) {
-      alert(error instanceof Error ? error.message : 'Could not save comment');
-    }
+      toast('Comment saved locally');
+    } catch (error) { toast(error instanceof Error ? error.message : 'Could not save comment'); }
+    finally { button.disabled = false; }
   });
   document.querySelector('#search').addEventListener('input', (event) => { state.search = event.target.value; renderFindings(); });
   document.querySelectorAll('[data-severity]').forEach((button) => button.addEventListener('click', () => { state.severity = button.dataset.severity; document.querySelectorAll('[data-severity]').forEach((item) => item.setAttribute('aria-pressed', String(item === button))); renderFindings(); }));
   document.querySelectorAll('[data-status]').forEach((button) => button.addEventListener('click', () => { state.status = button.dataset.status; document.querySelectorAll('[data-status]').forEach((item) => item.setAttribute('aria-pressed', String(item === button))); renderFindings(); }));
-  Promise.all([request('/api/review'), refreshComments()]).then(([review]) => { state.review = review; render(); }).catch((error) => { document.querySelector('#review-summary').textContent = 'Unable to load review: ' + error.message; });
+  Promise.all([request('/api/review'), refreshComments()]).then(([reviewData]) => { state.review = reviewData; render(); }).catch((error) => { document.querySelector('#review-title').textContent = 'Unable to load review'; document.querySelector('#review-summary').textContent = error.message; });
 })();
 </script>
 </body>
@@ -1521,6 +2076,8 @@ export async function main(
       'repo',
       'data-dir',
       'scenarios',
+      'presentation',
+
       'spec',
       'requirements',
       'base-commit',
@@ -1531,6 +2088,8 @@ export async function main(
       repoPath: option(values, 'repo'),
       dataDir: option(values, 'data-dir'),
       scenariosPath: option(values, 'scenarios'),
+      presentationPath: option(values, 'presentation'),
+
       specification: option(values, 'spec'),
       requirementsPath: option(values, 'requirements'),
       baseCommit: option(values, 'base-commit'),
@@ -1564,7 +2123,7 @@ export async function main(
     return;
   }
   throw new Error(
-    'Usage: review-site.ts prepare --review-json <structured-review.json> --scenarios <scenario-sidecar.json> --pr <number-or-url> [--spec <text> | --requirements <repo-relative-file>] [--base-commit <sha>]\n       review-site.ts serve --workspace <path> [--host 127.0.0.1] [--port 0] [--expose]',
+    'Usage: review-site.ts prepare --review-json <structured-review.json> --scenarios <scenario-sidecar.json> --pr <number-or-url> [--presentation <presentation-sidecar.json>] [--spec <text> | --requirements <repo-relative-file>] [--base-commit <sha>]\n       review-site.ts serve --workspace <path> [--host 127.0.0.1] [--port 0] [--expose]',
   );
 }
 

--- a/src/core/marketplace.ts
+++ b/src/core/marketplace.ts
@@ -885,6 +885,16 @@ export async function findMarketplace(
     await findMarketplaceRegistration(name, sourceLocation, workspacePath)
   )?.entry ?? null;
 }
+interface MarketplaceUpdateGitClient {
+  raw(args: string[]): Promise<string>;
+  checkout(branch: string): Promise<unknown>;
+}
+
+interface MarketplaceUpdateDeps {
+  createGit(path: string): MarketplaceUpdateGitClient;
+  pull(path: string): Promise<void>;
+}
+
 
 /**
  * Update marketplace(s) by pulling latest changes
@@ -893,6 +903,7 @@ export async function findMarketplace(
 export async function updateMarketplace(
   name?: string,
   workspacePath?: string,
+  deps: Partial<MarketplaceUpdateDeps> = {},
 ): Promise<Array<{ name: string; success: boolean; error?: string }>> {
   const userRegistry = await loadRegistry();
   let projectRegistry: MarketplaceRegistry | undefined;
@@ -991,7 +1002,7 @@ export async function updateMarketplace(
       const storedBranch = marketplace.source.type === 'github'
         ? parseLocation(marketplace.source.location).branch
         : undefined;
-      const git = simpleGit(marketplace.path);
+      const git = (deps.createGit ?? simpleGit)(marketplace.path);
 
       let targetBranch: string;
       if (storedBranch) {
@@ -1024,7 +1035,7 @@ export async function updateMarketplace(
       }
 
       await git.checkout(targetBranch);
-      await pull(marketplace.path);
+      await (deps.pull ?? pull)(marketplace.path);
 
       // Update lastUpdated in the entry (mutates in place for scope tracking)
       marketplace.lastUpdated = new Date().toISOString();

--- a/src/core/marketplace.ts
+++ b/src/core/marketplace.ts
@@ -895,7 +895,6 @@ interface MarketplaceUpdateDeps {
   pull(path: string): Promise<void>;
 }
 
-
 /**
  * Update marketplace(s) by pulling latest changes
  * @param name - Optional marketplace name (updates all if not specified)

--- a/tests/unit/core/marketplace-update.test.ts
+++ b/tests/unit/core/marketplace-update.test.ts
@@ -111,12 +111,11 @@ describe('updateMarketplace', () => {
 
   it('should use remote show origin to detect master branch when symbolic-ref fails', async () => {
     currentMockGit = createMockGit({
-      raw: (...args: unknown[]) => {
-        const rawArgs = args[0] as string[];
-        if (rawArgs?.[0] === 'symbolic-ref') {
+      raw: (args: string[]) => {
+        if (args[0] === 'symbolic-ref') {
           return Promise.reject(new Error('fatal: ref not found'));
         }
-        if (rawArgs?.[0] === 'remote' && rawArgs?.[1] === 'show') {
+        if (args[0] === 'remote' && args[1] === 'show') {
           return Promise.resolve('  HEAD branch: master\n  Remote branches:\n');
         }
         return Promise.resolve('');
@@ -139,12 +138,11 @@ describe('updateMarketplace', () => {
 
   it('should fallback to main when both symbolic-ref and remote show fail', async () => {
     currentMockGit = createMockGit({
-      raw: (...args: unknown[]) => {
-        const rawArgs = args[0] as string[];
-        if (rawArgs?.[0] === 'symbolic-ref') {
+      raw: (args: string[]) => {
+        if (args[0] === 'symbolic-ref') {
           return Promise.reject(new Error('fatal: ref not found'));
         }
-        if (rawArgs?.[0] === 'remote') {
+        if (args[0] === 'remote') {
           return Promise.reject(new Error('fatal: unable to access'));
         }
         return Promise.resolve('');

--- a/tests/unit/core/marketplace-update.test.ts
+++ b/tests/unit/core/marketplace-update.test.ts
@@ -1,29 +1,33 @@
-import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
-import { mkdirSync, readFileSync, writeFileSync, rmSync } from 'node:fs';
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import { updateMarketplace } from '../../../src/core/marketplace.js';
 import { stubHomeDir } from '../../helpers/env.js';
 
 // Track calls for assertions
 const simpleGitCalls: Array<{ method: string; args: unknown[] }> = [];
 const pullCalls: Array<{ path: string }> = [];
 
-// Create a mock simple-git instance
-function createMockGit(overrides: Record<string, (...args: unknown[]) => unknown> = {}) {
+function createMockGit(
+  overrides: {
+    raw?: (args: string[]) => Promise<string>;
+    checkout?: (branch: string) => Promise<void>;
+  } = {},
+) {
   return {
-    raw: mock((...args: unknown[]) => {
-      simpleGitCalls.push({ method: 'raw', args });
-      if (overrides.raw) return overrides.raw(...args);
+    raw: mock((args: string[]) => {
+      simpleGitCalls.push({ method: 'raw', args: [args] });
+      if (overrides.raw) return overrides.raw(args);
       // Default: symbolic-ref returns origin/main
-      const rawArgs = args[0] as string[];
-      if (rawArgs?.[0] === 'symbolic-ref') {
+      if (args[0] === 'symbolic-ref') {
         return Promise.resolve('origin/main');
       }
       return Promise.resolve('');
     }),
-    checkout: mock((...args: unknown[]) => {
-      simpleGitCalls.push({ method: 'checkout', args });
-      if (overrides.checkout) return overrides.checkout(...args);
+    checkout: mock((branch: string) => {
+      simpleGitCalls.push({ method: 'checkout', args: [branch] });
+      if (overrides.checkout) return overrides.checkout(branch);
       return Promise.resolve();
     }),
   };
@@ -31,33 +35,14 @@ function createMockGit(overrides: Record<string, (...args: unknown[]) => unknown
 
 let currentMockGit = createMockGit();
 
-mock.module('simple-git', () => ({
-  default: () => currentMockGit,
-}));
-
-// Mock the git module's pull function
-mock.module('../../../src/core/git.js', () => ({
-  createGitEnv: () => ({
-    ...process.env,
-    GIT_TERMINAL_PROMPT: '0',
-    GIT_LFS_SKIP_SMUDGE: '1',
-  }),
-  pull: mock((path: string) => {
-    pullCalls.push({ path });
-    return Promise.resolve();
-  }),
-  cloneToTemp: mock(() => Promise.resolve('/tmp/fake')),
-  cloneTo: mock(() => Promise.resolve()),
-  repoExists: mock(() => Promise.resolve(true)),
-  refExists: mock(() => Promise.resolve(true)),
-  cleanupTempDir: mock(() => Promise.resolve()),
-  classifyError: (error: Error) => error,
-  gitHubUrl: (owner: string, repo: string) => `https://github.com/${owner}/${repo}.git`,
-  GitCloneError: class extends Error {},
-}));
-
-// Must import after mock.module
-const { updateMarketplace } = await import('../../../src/core/marketplace.js');
+function marketplaceUpdateDeps() {
+  return {
+    createGit: () => currentMockGit,
+    pull: async (path: string) => {
+      pullCalls.push({ path });
+    },
+  };
+}
 
 describe('updateMarketplace', () => {
   let restoreHomeDir: () => void;
@@ -102,7 +87,11 @@ describe('updateMarketplace', () => {
   });
 
   it('should checkout default branch before pulling', async () => {
-    const results = await updateMarketplace('test-mp');
+    const results = await updateMarketplace(
+      'test-mp',
+      undefined,
+      marketplaceUpdateDeps(),
+    );
 
     expect(results).toHaveLength(1);
     expect(results[0].success).toBe(true);
@@ -134,7 +123,11 @@ describe('updateMarketplace', () => {
       },
     });
 
-    const results = await updateMarketplace('test-mp');
+    const results = await updateMarketplace(
+      'test-mp',
+      undefined,
+      marketplaceUpdateDeps(),
+    );
 
     expect(results).toHaveLength(1);
     expect(results[0].success).toBe(true);
@@ -158,7 +151,11 @@ describe('updateMarketplace', () => {
       },
     });
 
-    const results = await updateMarketplace('test-mp');
+    const results = await updateMarketplace(
+      'test-mp',
+      undefined,
+      marketplaceUpdateDeps(),
+    );
 
     expect(results).toHaveLength(1);
     expect(results[0].success).toBe(true);
@@ -189,7 +186,11 @@ describe('updateMarketplace', () => {
 
     simpleGitCalls.length = 0;
 
-    const results = await updateMarketplace('test-mp-branch');
+    const results = await updateMarketplace(
+      'test-mp-branch',
+      undefined,
+      marketplaceUpdateDeps(),
+    );
 
     expect(results).toHaveLength(1);
     expect(results[0].success).toBe(true);
@@ -227,7 +228,11 @@ describe('updateMarketplace', () => {
       }),
     );
 
-    const results = await updateMarketplace('unsafe');
+    const results = await updateMarketplace(
+      'unsafe',
+      undefined,
+      marketplaceUpdateDeps(),
+    );
 
     expect(results).toHaveLength(1);
     expect(results[0].success).toBe(false);
@@ -264,7 +269,11 @@ describe('updateMarketplace', () => {
       }),
     );
 
-    const results = await updateMarketplace();
+    const results = await updateMarketplace(
+      undefined,
+      undefined,
+      marketplaceUpdateDeps(),
+    );
 
     expect(results).toHaveLength(2);
     const registry = JSON.parse(readFileSync(registryPath, 'utf-8'));

--- a/tests/unit/core/workspace-modify.test.ts
+++ b/tests/unit/core/workspace-modify.test.ts
@@ -5,12 +5,32 @@ import { tmpdir } from 'node:os';
 import { dump, load } from 'js-yaml';
 import type { WorkspaceConfig } from '../../../src/models/workspace-config.js';
 
+// Bun module mocks update live bindings and persist across test files. Keep the
+// unrelated pull export functional so this verification stub cannot disable
+// later integration tests that exercise real cached repositories.
+async function pullWithGit(path: string): Promise<void> {
+  const result = Bun.spawnSync(['git', '-C', path, 'pull'], {
+    env: {
+      ...process.env,
+      GIT_LFS_SKIP_SMUDGE: '1',
+      GIT_TERMINAL_PROMPT: '0',
+    },
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `git pull failed in ${path}: ${result.stderr.toString().trim()}`,
+    );
+  }
+}
+
 // Mock git module to avoid network calls in verifyGitHubUrlExists
 mock.module('../../../src/core/git.js', () => ({
   repoExists: async () => true,
   cloneToTemp: async () => '',
   cloneTo: async () => {},
-  pull: async () => {},
+  pull: pullWithGit,
   refExists: async () => false,
   cleanupTempDir: async () => {},
   gitHubUrl: (owner: string, repo: string) => `https://github.com/${owner}/${repo}.git`,

--- a/tests/unit/plugins/pr-interactive-review.test.ts
+++ b/tests/unit/plugins/pr-interactive-review.test.ts
@@ -317,6 +317,137 @@ describe('pr-interactive-review', () => {
       (await readdir(prepared.workspace)).some((name) => name.endsWith('.tmp')),
     ).toBe(false);
   });
+  it('stores a bounded presentation sidecar for reusable editorial context', async () => {
+    const prepared = await fixture();
+    const presentation = join(prepared.repository, 'interactive-presentation.json');
+    await writeFile(
+      presentation,
+      JSON.stringify({
+        eyebrow: 'Runtime seam review',
+        headline: 'One queue connects two services.',
+        summary: 'Review the handoff before implementation detail.',
+        context_cards: [
+          {
+            label: 'System boundary',
+            title: 'Dispatcher to Runner',
+            body: 'The Dispatcher starts work and the Runner owns execution.',
+            tone: 'problem',
+          },
+        ],
+        mental_model: {
+          title: 'The execution path',
+          summary: 'One shared contract crosses the Temporal boundary.',
+          steps: [
+            {
+              label: '01 / Dispatch',
+              title: 'Start workflow',
+              body: 'Create the workflow with the configured task queue.',
+            },
+          ],
+        },
+      }),
+    );
+    const refreshed = await prepareReview({
+      reviewJsonPath: prepared.artifact,
+      pr: '123',
+      repoPath: prepared.repository,
+      dataDir: prepared.state,
+      scenariosPath: prepared.scenarios,
+      presentationPath: presentation,
+    });
+    expect(refreshed.review.presentation).toEqual({
+      eyebrow: 'Runtime seam review',
+      headline: 'One queue connects two services.',
+      summary: 'Review the handoff before implementation detail.',
+      contextCards: [
+        {
+          label: 'System boundary',
+          title: 'Dispatcher to Runner',
+          body: 'The Dispatcher starts work and the Runner owns execution.',
+          tone: 'problem',
+        },
+      ],
+      mentalModel: {
+        title: 'The execution path',
+        summary: 'One shared contract crosses the Temporal boundary.',
+        steps: [
+          {
+            label: '01 / Dispatch',
+            title: 'Start workflow',
+            body: 'Create the workflow with the configured task queue.',
+          },
+        ],
+      },
+    });
+    const preserved = await prepareReview({
+      reviewJsonPath: prepared.artifact,
+      pr: '123',
+      repoPath: prepared.repository,
+      dataDir: prepared.state,
+      scenariosPath: prepared.scenarios,
+    });
+    expect(preserved.review.presentation).toEqual(refreshed.review.presentation);
+    await writeFile(
+      presentation,
+      JSON.stringify({
+        eyebrow: 'Review',
+        headline: 'Too many cards',
+        summary: 'Reject unbounded presentation content.',
+        context_cards: Array.from({ length: 7 }, (_, index) => ({
+          label: `Card ${index}`,
+          title: 'Title',
+          body: 'Body',
+        })),
+      }),
+    );
+    await expect(
+      prepareReview({
+        reviewJsonPath: prepared.artifact,
+        pr: '123',
+        repoPath: prepared.repository,
+        dataDir: prepared.state,
+        presentationPath: presentation,
+      }),
+    ).rejects.toThrow('array of at most 6 objects');
+    await writeFile(presentation, 'null');
+    await expect(
+      prepareReview({
+        reviewJsonPath: prepared.artifact,
+        pr: '123',
+        repoPath: prepared.repository,
+        dataDir: prepared.state,
+        presentationPath: presentation,
+      }),
+    ).rejects.toThrow('presentation must be an object');
+    const changedArtifact = JSON.parse(
+      await readFile(prepared.artifact, 'utf8'),
+    ) as { scope: { head_sha: string } };
+    changedArtifact.scope.head_sha =
+      'fedcba9876543210fedcba9876543210fedcba98';
+    await writeFile(prepared.artifact, JSON.stringify(changedArtifact));
+    const changedCommit = await prepareReview({
+      reviewJsonPath: prepared.artifact,
+      pr: '123',
+      repoPath: prepared.repository,
+      dataDir: prepared.state,
+    });
+    expect(changedCommit.review.presentation).toBeNull();
+  });
+  it('rejects invalid persisted presentation metadata before browser rendering', async () => {
+    const prepared = await fixture();
+    const reviewPath = join(prepared.workspace, 'review.json');
+    const stored = JSON.parse(await readFile(reviewPath, 'utf8')) as Record<
+      string,
+      unknown
+    >;
+    stored.presentation = { contextCards: {} };
+    await writeFile(reviewPath, JSON.stringify(stored));
+    await expect(loadStoredReview(prepared.workspace)).rejects.toThrow(
+      'presentation.context_cards must be an array',
+    );
+  });
+
+
 
   it('escapes untrusted page values and keeps business context before findings', async () => {
     const prepared = await fixture();
@@ -331,6 +462,26 @@ describe('pr-interactive-review', () => {
     );
     expect(page).not.toContain('Assistant reply');
   });
+  it('renders a navigable review shell with heavy detail collapsed by default', async () => {
+    const prepared = await fixture();
+    const page = renderReviewPage(prepared.review);
+    expect(page).toContain('class="review-shell"');
+    expect(page).toContain('id="review-nav"');
+    expect(page).toContain('class="hero-metrics"');
+    expect(page).toContain("disclosure('Supplied requirements'");
+    expect(page).toContain("disclosure('Referenced evidence");
+    expect(page).toContain("disclosure('Focused code context'");
+    expect(page).toContain('@media (max-width: 900px)');
+    expect(page).toContain(
+      '<a class="skip-link" href="#findings-section">Skip to findings</a>',
+    );
+    expect(page).toContain('renderFindingNav(visible);');
+    const renderFindings = page.indexOf('function renderFindings()');
+    expect(
+      page.indexOf('state.observer.disconnect()', renderFindings),
+    ).toBeLessThan(page.indexOf('root.replaceChildren()', renderFindings));
+  });
+
 
   it('contains long prose fields and reviewed lines without breaking narrow cards', async () => {
     const prepared = await fixture();
@@ -354,13 +505,13 @@ describe('pr-interactive-review', () => {
     expect(page).toContain('.finding { min-width: 0;');
     expect(page).toContain('aria-label="Finding status filters"');
     expect(page).toContain("withdrawn: 'Withdrawn findings'");
-    expect(page).toContain("el('h3', 'Lifecycle history')");
+    expect(page).toContain("disclosure('Lifecycle history'");
     expect(page).toContain(
-      '.finding-top, .finding-top > *, .excerpt-grid, .excerpt-grid > * { min-width: 0; }',
+      '.context-grid, .model-grid, .scenario-grid, .excerpt-grid { grid-template-columns: 1fr; }',
     );
-    expect(page).toContain('p, li, label, strong, .meta, .gap { overflow-wrap: anywhere; word-break: break-word; }');
+    expect(page).toContain('h1, h2, h3, h4, p, li, label, strong, .meta, .gap, .rail-link-label { overflow-wrap: anywhere; word-break: break-word; }');
     expect(page).toContain(
-      'pre { max-width: 100%; min-width: 0; overflow-x: auto; white-space: pre;',
+      'pre { max-width: 100%; min-width: 0; margin: 0; overflow-x: auto; white-space: pre;',
     );
   });
 


### PR DESCRIPTION
## Summary

Interactive PR reviews now reproduce the same editorial hierarchy for any pull request: intent and verdict first, bounded business context and an optional mental model next, then filterable findings. The design comes from a validated presentation contract instead of one-off HTML, while existing review workspaces and finding lifecycle state remain compatible.

## Design

- A bounded `interactive-presentation.json` sidecar carries review-specific editorial content into the shared renderer.
- The shared shell uses a sticky desktop review map and a single-column mobile layout, with heavy requirements, evidence, code, and lifecycle history collapsed by default.
- Presentation metadata survives same-commit regeneration, resets when the reviewed commit changes, and rejects malformed persisted or supplied values.
- Search and status filters keep the finding rail aligned with visible targets. Keyboard users can skip directly to findings.

## Validation

- `bun run test` — 1,476 passed, 5 skipped, 0 failed.
- `bun run typecheck` — passed.
- `bun run build` — passed.
- Browser-tested the generated review at desktop and 390×844 mobile sizes. Confirmed responsive layout, no document-level horizontal overflow, collapsed heavy details, filtered navigation targets, and the empty-results state.
