### PR TITLE
fix(cli): preserve Windows command arguments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,3 +73,15 @@ jobs:
           bun-version-file: package.json
       - run: bun install --frozen-lockfile --ignore-scripts
       - run: bun run test
+
+  windows-command-argv:
+    name: Windows command argv
+    runs-on: windows-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: package.json
+      - run: bun install --frozen-lockfile --ignore-scripts
+      - run: bun test tests/unit/core/native/types.test.ts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,4 +84,4 @@ jobs:
         with:
           bun-version-file: package.json
       - run: bun install --frozen-lockfile --ignore-scripts
-      - run: bun test tests/unit/core/native/types.test.ts
+      - run: bun test tests/unit/core/native/types.test.ts tests/unit/cli/workspace-setup-command.test.ts

--- a/bun.lock
+++ b/bun.lock
@@ -15,6 +15,7 @@
         "js-yaml": "^4.1.0",
         "json5": "^2.2.3",
         "micromatch": "^4.0.8",
+        "read-cmd-shim": "^4.0.0",
         "simple-git": "^3.30.0",
         "zod": "^3.22.4",
       },
@@ -306,6 +307,8 @@
     "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
 
     "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
+
+    "read-cmd-shim": ["read-cmd-shim@4.0.0", "", {}, "sha512-yILWifhaSEEytfXI76kB9xEEiG1AiozaCJZ83A87ytjRiN+jVibXjedjCRNjoZviinhG+4UkalO3mWTd8u5O0Q=="],
 
     "rechoir": ["rechoir@0.6.2", "", { "dependencies": { "resolve": "^1.1.6" } }, "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw=="],
 

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "js-yaml": "^4.1.0",
     "json5": "^2.2.3",
     "micromatch": "^4.0.8",
+    "read-cmd-shim": "^4.0.0",
     "simple-git": "^3.30.0",
     "zod": "^3.22.4"
   },

--- a/src/core/native/types.ts
+++ b/src/core/native/types.ts
@@ -1,7 +1,7 @@
 import { spawn } from 'node:child_process';
 import { once } from 'node:events';
 import { access, open } from 'node:fs/promises';
-import { delimiter, dirname, extname, join, resolve } from 'node:path';
+import { delimiter, dirname, extname, resolve } from 'node:path';
 import readCmdShim from 'read-cmd-shim';
 
 export interface NativeCommandResult {
@@ -54,30 +54,43 @@ export interface NativeClient {
   syncPlugins(plugins: string[], scope: 'user' | 'project', options?: { cwd?: string; dryRun?: boolean }): Promise<NativeSyncResult>;
 }
 
-async function resolveWindowsBinary(binary: string): Promise<string> {
+async function resolveWindowsBinary(
+  binary: string,
+  nativeOnly = false,
+): Promise<string> {
   const pathEntries = /[\\/]/.test(binary)
     ? ['']
-    : (process.env.PATH ?? '').split(delimiter);
-  const configuredExtensions = (
-    process.env.PATHEXT ?? '.COM;.EXE;.BAT;.CMD'
-  )
+    : (process.env.PATH ?? '')
+        .split(delimiter)
+        .map((pathEntry) => {
+          const trimmed = pathEntry.trim();
+          return trimmed.startsWith('"') && trimmed.endsWith('"')
+            ? trimmed.slice(1, -1)
+            : trimmed;
+        })
+        // Empty Windows PATH entries mean cwd, but client binaries must come
+        // from an explicit PATH directory rather than the workspace.
+        .filter((pathEntry) => pathEntry.length > 0);
+  const configuredExtensions = (process.env.PATHEXT ?? '.COM;.EXE;.BAT;.CMD')
     .split(delimiter)
-    .map((extension) => extension.toLowerCase());
+    .map((extension) => {
+      const normalized = extension.trim().toLowerCase();
+      return normalized && !normalized.startsWith('.')
+        ? `.${normalized}`
+        : normalized;
+    })
+    .filter((extension) => extension.length > 0);
   const extensions = extname(binary)
-    ? ['', ...configuredExtensions]
-    : configuredExtensions;
+    ? ['']
+    : nativeOnly
+      ? configuredExtensions.filter(
+          (extension) => extension === '.com' || extension === '.exe',
+        )
+      : configuredExtensions;
 
-  for (const pathEntry of pathEntries) {
-    const directory =
-      pathEntry.startsWith('"') && pathEntry.endsWith('"')
-        ? pathEntry.slice(1, -1)
-        : pathEntry;
+  for (const directory of pathEntries) {
     for (const extension of extensions) {
-      const candidate = resolve(
-        directory
-          ? join(directory, `${binary}${extension}`)
-          : `${binary}${extension}`,
-      );
+      const candidate = resolve(directory, `${binary}${extension}`);
       try {
         await access(candidate);
         return candidate;
@@ -90,18 +103,47 @@ async function resolveWindowsBinary(binary: string): Promise<string> {
   throw new Error(`command not found on PATH: ${binary}`);
 }
 
+async function resolveWindowsNativeBinary(binary: string): Promise<string> {
+  const extension = extname(binary).toLowerCase();
+  if (extension && extension !== '.com' && extension !== '.exe') {
+    throw new Error(`unsafe Windows interpreter '${binary}'`);
+  }
+  return resolveWindowsBinary(binary, true);
+}
+
+async function resolveWindowsShimInterpreter(
+  interpreter: string,
+  shimDirectory: string,
+): Promise<string> {
+  const normalizedInterpreter = interpreter.toLowerCase();
+  if (
+    normalizedInterpreter !== 'node' &&
+    normalizedInterpreter !== 'node.exe'
+  ) {
+    throw new Error(`unsupported command shim interpreter '${interpreter}'`);
+  }
+
+  const siblingNode = resolve(shimDirectory, 'node.exe');
+  try {
+    await access(siblingNode);
+    return siblingNode;
+  } catch {
+    return resolveWindowsNativeBinary(interpreter);
+  }
+}
+
 async function resolveWindowsCommand(
   binary: string,
   args: string[],
 ): Promise<{ binary: string; args: string[] }> {
   const resolvedBinary = await resolveWindowsBinary(binary);
   const extension = extname(resolvedBinary).toLowerCase();
-  if (extension === '.bat') {
-    throw new Error(
-      `cannot safely execute Windows batch file '${resolvedBinary}'`,
-    );
-  }
   if (extension !== '.cmd') {
+    if (extension !== '.com' && extension !== '.exe') {
+      throw new Error(
+        `cannot safely execute Windows command '${resolvedBinary}'`,
+      );
+    }
     return { binary: resolvedBinary, args };
   }
 
@@ -109,6 +151,14 @@ async function resolveWindowsCommand(
     dirname(resolvedBinary),
     await readCmdShim(resolvedBinary),
   );
+  const targetExtension = extname(target).toLowerCase();
+  if (
+    targetExtension === '.bat' ||
+    targetExtension === '.cmd' ||
+    targetExtension === '.ps1'
+  ) {
+    throw new Error(`cannot safely execute command shim target '${target}'`);
+  }
   const file = await open(target, 'r');
   const buffer = Buffer.alloc(256);
   let bytesRead = 0;
@@ -120,12 +170,17 @@ async function resolveWindowsCommand(
   const [firstLine = ''] = buffer
     .toString('utf8', 0, bytesRead)
     .split(/\r?\n/, 1);
-  const shebang = firstLine.match(/^#!\s*(?:\/usr\/bin\/env\s+)?([^ \t]+)\s*$/);
+  const shebang = firstLine.match(
+    /^#!\s*(?:\/usr\/bin\/env\s+(?:-S\s+)?)?([^ \t]+)\s*$/,
+  );
   if (!shebang) {
     if (firstLine.startsWith('#!')) {
       throw new Error(
         `unsupported command shim shebang in '${resolvedBinary}'`,
       );
+    }
+    if (targetExtension !== '.com' && targetExtension !== '.exe') {
+      throw new Error(`unsupported command shim target '${target}'`);
     }
     return { binary: target, args };
   }
@@ -136,7 +191,10 @@ async function resolveWindowsCommand(
   }
 
   return {
-    binary: await resolveWindowsBinary(interpreter),
+    binary: await resolveWindowsShimInterpreter(
+      interpreter,
+      dirname(resolvedBinary),
+    ),
     args: [target, ...args],
   };
 }
@@ -163,23 +221,23 @@ export async function executeCommand(
     }
   }
 
-  const proc = spawn(command.binary, command.args, {
-    cwd: options.cwd,
-    stdio: ['ignore', 'pipe', 'pipe'],
-    env: { ...process.env },
-  });
-
-  let stdout = '';
-  let stderr = '';
-
-  proc.stdout.on('data', (data: Buffer) => {
-    stdout += data.toString();
-  });
-  proc.stderr.on('data', (data: Buffer) => {
-    stderr += data.toString();
-  });
-
   try {
+    const proc = spawn(command.binary, command.args, {
+      cwd: options.cwd,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: { ...process.env },
+    });
+
+    let stdout = '';
+    let stderr = '';
+
+    proc.stdout.on('data', (data: Buffer) => {
+      stdout += data.toString();
+    });
+    proc.stderr.on('data', (data: Buffer) => {
+      stderr += data.toString();
+    });
+
     const [code] = (await once(proc, 'close')) as [number | null];
     const trimmedStderr = stderr.trim();
     return {

--- a/src/core/native/types.ts
+++ b/src/core/native/types.ts
@@ -60,7 +60,9 @@ async function resolveWindowsBinary(binary: string): Promise<string> {
     : (process.env.PATH ?? '').split(delimiter);
   const configuredExtensions = (
     process.env.PATHEXT ?? '.COM;.EXE;.BAT;.CMD'
-  ).split(delimiter);
+  )
+    .split(delimiter)
+    .map((extension) => extension.toLowerCase());
   const extensions = extname(binary)
     ? ['', ...configuredExtensions]
     : configuredExtensions;

--- a/src/core/native/types.ts
+++ b/src/core/native/types.ts
@@ -1,4 +1,8 @@
 import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+import { access, open } from 'node:fs/promises';
+import { delimiter, dirname, extname, join, resolve } from 'node:path';
+import readCmdShim from 'read-cmd-shim';
 
 export interface NativeCommandResult {
   success: boolean;
@@ -50,55 +54,144 @@ export interface NativeClient {
   syncPlugins(plugins: string[], scope: 'user' | 'project', options?: { cwd?: string; dryRun?: boolean }): Promise<NativeSyncResult>;
 }
 
+async function resolveWindowsBinary(binary: string): Promise<string> {
+  const pathEntries = /[\\/]/.test(binary)
+    ? ['']
+    : (process.env.PATH ?? '').split(delimiter);
+  const configuredExtensions = (
+    process.env.PATHEXT ?? '.COM;.EXE;.BAT;.CMD'
+  ).split(delimiter);
+  const extensions = extname(binary)
+    ? ['', ...configuredExtensions]
+    : configuredExtensions;
+
+  for (const pathEntry of pathEntries) {
+    const directory =
+      pathEntry.startsWith('"') && pathEntry.endsWith('"')
+        ? pathEntry.slice(1, -1)
+        : pathEntry;
+    for (const extension of extensions) {
+      const candidate = resolve(
+        directory
+          ? join(directory, `${binary}${extension}`)
+          : `${binary}${extension}`,
+      );
+      try {
+        await access(candidate);
+        return candidate;
+      } catch {
+        // Continue through PATH.
+      }
+    }
+  }
+
+  throw new Error(`command not found on PATH: ${binary}`);
+}
+
+async function resolveWindowsCommand(
+  binary: string,
+  args: string[],
+): Promise<{ binary: string; args: string[] }> {
+  const resolvedBinary = await resolveWindowsBinary(binary);
+  const extension = extname(resolvedBinary).toLowerCase();
+  if (extension === '.bat') {
+    throw new Error(
+      `cannot safely execute Windows batch file '${resolvedBinary}'`,
+    );
+  }
+  if (extension !== '.cmd') {
+    return { binary: resolvedBinary, args };
+  }
+
+  const target = resolve(
+    dirname(resolvedBinary),
+    await readCmdShim(resolvedBinary),
+  );
+  const file = await open(target, 'r');
+  const buffer = Buffer.alloc(256);
+  let bytesRead = 0;
+  try {
+    ({ bytesRead } = await file.read(buffer, 0, buffer.length, 0));
+  } finally {
+    await file.close();
+  }
+  const [firstLine = ''] = buffer
+    .toString('utf8', 0, bytesRead)
+    .split(/\r?\n/, 1);
+  const shebang = firstLine.match(/^#!\s*(?:\/usr\/bin\/env\s+)?([^ \t]+)\s*$/);
+  if (!shebang) {
+    if (firstLine.startsWith('#!')) {
+      throw new Error(
+        `unsupported command shim shebang in '${resolvedBinary}'`,
+      );
+    }
+    return { binary: target, args };
+  }
+
+  const interpreter = shebang[1];
+  if (!interpreter) {
+    throw new Error(`missing command shim interpreter in '${resolvedBinary}'`);
+  }
+
+  return {
+    binary: await resolveWindowsBinary(interpreter),
+    args: [target, ...args],
+  };
+}
+
 /**
  * Execute a CLI command and capture output.
  * Shared helper for all native client implementations.
  */
-export function executeCommand(
+export async function executeCommand(
   binary: string,
   args: string[],
   options: { cwd?: string } = {},
 ): Promise<NativeCommandResult> {
-  return new Promise((resolve) => {
-    const proc = spawn(binary, args, {
-      cwd: options.cwd,
-      stdio: ['ignore', 'pipe', 'pipe'],
-      shell: process.platform === 'win32',
-      env: { ...process.env },
-    });
-
-    let stdout = '';
-    let stderr = '';
-
-    proc.stdout.on('data', (data: Buffer) => {
-      stdout += data.toString();
-    });
-    proc.stderr.on('data', (data: Buffer) => {
-      stderr += data.toString();
-    });
-
-    let resolved = false;
-    proc.on('close', (code: number | null) => {
-      if (resolved) return;
-      resolved = true;
-      const trimmedStderr = stderr.trim();
-      resolve({
-        success: code === 0,
-        output: stdout.trim(),
-        ...(trimmedStderr && { error: trimmedStderr }),
-      });
-    });
-
-    proc.on('error', (err: Error) => {
-      if (resolved) return;
-      resolved = true;
-      resolve({
+  let command = { binary, args };
+  if (process.platform === 'win32') {
+    try {
+      command = await resolveWindowsCommand(binary, args);
+    } catch (err) {
+      return {
         success: false,
         output: '',
-        error: `Failed to execute ${binary} CLI: ${err.message}`,
-      });
-    });
+        error: `Failed to execute ${binary} CLI: ${err instanceof Error ? err.message : String(err)}`,
+      };
+    }
+  }
+
+  const proc = spawn(command.binary, command.args, {
+    cwd: options.cwd,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: { ...process.env },
   });
+
+  let stdout = '';
+  let stderr = '';
+
+  proc.stdout.on('data', (data: Buffer) => {
+    stdout += data.toString();
+  });
+  proc.stderr.on('data', (data: Buffer) => {
+    stderr += data.toString();
+  });
+
+  try {
+    const [code] = (await once(proc, 'close')) as [number | null];
+    const trimmedStderr = stderr.trim();
+    return {
+      success: code === 0,
+      output: stdout.trim(),
+      ...(trimmedStderr && { error: trimmedStderr }),
+    };
+  } catch (err) {
+    return {
+      success: false,
+      output: '',
+      error: `Failed to execute ${binary} CLI: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
 }
 
 /**

--- a/src/types/read-cmd-shim.d.ts
+++ b/src/types/read-cmd-shim.d.ts
@@ -1,0 +1,4 @@
+declare module 'read-cmd-shim' {
+  function readCmdShim(path: string): Promise<string>;
+  export default readCmdShim;
+}

--- a/tests/unit/cli/workspace-setup-command.test.ts
+++ b/tests/unit/cli/workspace-setup-command.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { afterAll, beforeEach, describe, expect, test } from 'bun:test';
 import {
   existsSync,
   mkdirSync,
@@ -71,6 +71,7 @@ function writeWorkspace(root: string, setup: SetupFixture[]): void {
 
 describe('workspace setup command', () => {
   let testDir: string;
+  const testDirs: string[] = [];
 
   beforeEach(() => {
     testDir = join(
@@ -78,15 +79,18 @@ describe('workspace setup command', () => {
       `allagents-workspace-setup-${process.pid}-${Date.now()}`,
     );
     mkdirSync(testDir, { recursive: true });
+    testDirs.push(testDir);
   });
 
-  afterEach(() => {
-    rmSync(testDir, {
-      recursive: true,
-      force: true,
-      maxRetries: 5,
-      retryDelay: 100,
-    });
+  afterAll(() => {
+    for (const directory of testDirs) {
+      rmSync(directory, {
+        recursive: true,
+        force: true,
+        maxRetries: 5,
+        retryDelay: 100,
+      });
+    }
   });
 
   test('runs commands sequentially from the workspace root', () => {

--- a/tests/unit/cli/workspace-setup-command.test.ts
+++ b/tests/unit/cli/workspace-setup-command.test.ts
@@ -81,7 +81,12 @@ describe('workspace setup command', () => {
   });
 
   afterEach(() => {
-    rmSync(testDir, { recursive: true, force: true });
+    rmSync(testDir, {
+      recursive: true,
+      force: true,
+      maxRetries: 5,
+      retryDelay: 100,
+    });
   });
 
   test('runs commands sequentially from the workspace root', () => {
@@ -221,54 +226,57 @@ describe('workspace setup command', () => {
     expect(readFileSync(join(testDir, 'setup.log'), 'utf8')).toBe('first');
   });
 
-  test('preserves partial results when a command is terminated by a signal', () => {
-    const commands = [
-      fixtureCommand(
-        testDir,
-        'write-first',
-        "require('node:fs').writeFileSync('setup.log', 'first');",
-      ),
-      fixtureCommand(
-        testDir,
-        'terminate-shell',
-        "process.kill(process.ppid, 'SIGTERM');",
-      ),
-      fixtureCommand(
-        testDir,
-        'write-third',
-        "require('node:fs').appendFileSync('setup.log', '-third');",
-      ),
-    ];
-    writeWorkspace(testDir, commands);
+  test.skipIf(process.platform === 'win32')(
+    'preserves partial results when a command is terminated by a signal',
+    () => {
+      const commands = [
+        fixtureCommand(
+          testDir,
+          'write-first',
+          "require('node:fs').writeFileSync('setup.log', 'first');",
+        ),
+        fixtureCommand(
+          testDir,
+          'terminate-shell',
+          "process.kill(process.ppid, 'SIGTERM');",
+        ),
+        fixtureCommand(
+          testDir,
+          'write-third',
+          "require('node:fs').appendFileSync('setup.log', '-third');",
+        ),
+      ];
+      writeWorkspace(testDir, commands);
 
-    const proc = runCli(testDir, ['workspace', 'setup'], testDir);
+      const proc = runCli(testDir, ['workspace', 'setup'], testDir);
 
-    expect(proc.exitCode).toBe(1);
-    expect(JSON.parse(proc.stdout.toString())).toEqual({
-      success: false,
-      command: 'workspace setup',
-      data: {
-        commands: [
-          {
-            command: commands[0],
-            status: 'succeeded',
-            exitCode: 0,
-            signal: null,
-            reason: null,
-          },
-          {
-            command: commands[1],
-            status: 'failed',
-            exitCode: null,
-            signal: 'SIGTERM',
-            reason: null,
-          },
-        ],
-      },
-      error: `Setup command terminated by signal SIGTERM: ${commands[1]}`,
-    });
-    expect(readFileSync(join(testDir, 'setup.log'), 'utf8')).toBe('first');
-  });
+      expect(proc.exitCode).toBe(1);
+      expect(JSON.parse(proc.stdout.toString())).toEqual({
+        success: false,
+        command: 'workspace setup',
+        data: {
+          commands: [
+            {
+              command: commands[0],
+              status: 'succeeded',
+              exitCode: 0,
+              signal: null,
+              reason: null,
+            },
+            {
+              command: commands[1],
+              status: 'failed',
+              exitCode: null,
+              signal: 'SIGTERM',
+              reason: null,
+            },
+          ],
+        },
+        error: `Setup command terminated by signal SIGTERM: ${commands[1]}`,
+      });
+      expect(readFileSync(join(testDir, 'setup.log'), 'utf8')).toBe('first');
+    },
+  );
 
   test('runs only commands matching the current platform and architecture', () => {
     const otherPlatform: NodeJS.Platform =

--- a/tests/unit/core/native/types.test.ts
+++ b/tests/unit/core/native/types.test.ts
@@ -7,8 +7,16 @@ import type { NativeSyncResult } from '../../../../src/core/native/types.js';
 
 describe('native/types', () => {
   describe('executeCommand', () => {
+    test('returns process creation errors instead of rejecting', async () => {
+      const result = await executeCommand(process.execPath, ['invalid\0argument']);
+
+      expect(result.success).toBe(false);
+      expect(result.output).toBe('');
+      expect(result.error).toContain(`Failed to execute ${process.execPath} CLI`);
+    });
+
     test.skipIf(process.platform !== 'win32')(
-      'preserves npm shim behavior without DEP0190 on Windows',
+      'executes supported npm shims safely without DEP0190 on Windows',
       async () => {
         const tempDir = mkdtempSync(
           join(tmpdir(), 'allagents-execute-command-'),
@@ -16,6 +24,8 @@ describe('native/types', () => {
         const scriptDir = join(tempDir, 'node_modules', 'test-cli');
         const scriptPath = join(scriptDir, 'print-argv.cjs');
         const shimPath = join(tempDir, 'argv-recorder.cmd');
+        const nestedTargetPath = join(tempDir, 'nested-target.cmd');
+        const nestedShimPath = join(tempDir, 'nested-wrapper.cmd');
         const runnerPath = join(tempDir, 'run-execute-command.mjs');
         const args = [
           'value with spaces',
@@ -46,6 +56,15 @@ describe('native/types', () => {
             shimPath,
             '@ECHO off\r\nnode "%~dp0\\node_modules\\test-cli\\print-argv.cjs" %*\r\n',
           );
+          writeFileSync(
+            join(tempDir, 'node.cmd'),
+            '@ECHO off\r\nECHO unsafe interpreter selected\r\n',
+          );
+          writeFileSync(nestedTargetPath, '@ECHO off\r\nECHO nested batch ran\r\n');
+          writeFileSync(
+            nestedShimPath,
+            '@ECHO off\r\n"%~dp0\\nested-target.cmd" %*\r\n',
+          );
 
           const bundle = await Bun.build({
             entrypoints: [
@@ -60,8 +79,9 @@ describe('native/types', () => {
             runnerPath,
             [
               "import { executeCommand } from './types.js';",
+              "const command = process.env.ALLAGENTS_TEST_COMMAND ?? 'argv-recorder';",
               "const args = JSON.parse(process.env.ALLAGENTS_TEST_ARGS ?? '[]');",
-              "const result = await executeCommand('argv-recorder', args);",
+              'const result = await executeCommand(command, args);',
               'process.stdout.write(JSON.stringify(result));',
             ].join('\n'),
           );
@@ -74,8 +94,11 @@ describe('native/types', () => {
           const pathKey =
             Object.keys(env).find((key) => key.toLowerCase() === 'path') ??
             'PATH';
-          env[pathKey] =
-            `${tempDir}${delimiter}${env[pathKey] ?? ''}`;
+          const pathExtKey =
+            Object.keys(env).find((key) => key.toLowerCase() === 'pathext') ??
+            'PATHEXT';
+          const originalPath = env[pathKey] ?? '';
+          env[pathKey] = `${tempDir}${delimiter}${originalPath}`;
 
           for (const runtime of runtimes) {
             const proc = Bun.spawnSync([...runtime, runnerPath], {
@@ -97,6 +120,83 @@ describe('native/types', () => {
               output: JSON.stringify({ runtime: 'node', args }),
             });
           }
+
+          const nestedProc = Bun.spawnSync(['node', runnerPath], {
+            cwd: tempDir,
+            env: {
+              ...env,
+              ALLAGENTS_TEST_COMMAND: 'nested-wrapper',
+              ALLAGENTS_TEST_ARGS: JSON.stringify(args),
+            },
+            stdout: 'pipe',
+            stderr: 'pipe',
+          });
+          const nestedResult = JSON.parse(
+            new TextDecoder().decode(nestedProc.stdout),
+          );
+          expect(nestedProc.exitCode).toBe(0);
+          expect(new TextDecoder().decode(nestedProc.stderr)).toBe('');
+          expect(nestedResult).toMatchObject({
+            success: false,
+            output: '',
+          });
+          expect(nestedResult.error).toContain(
+            `cannot safely execute command shim target '${nestedTargetPath}'`,
+          );
+
+          writeFileSync(
+            join(tempDir, 'node.com'),
+            'This must not run when PATHEXT excludes .COM',
+          );
+          const filteredPathExtProc = Bun.spawnSync(
+            [process.execPath, runnerPath],
+            {
+              cwd: tempDir,
+              env: {
+                ...env,
+                [pathExtKey]: '.CMD;.EXE',
+                ALLAGENTS_TEST_ARGS: JSON.stringify(args),
+              },
+              stdout: 'pipe',
+              stderr: 'pipe',
+            },
+          );
+          expect(filteredPathExtProc.exitCode).toBe(0);
+          expect(
+            new TextDecoder().decode(filteredPathExtProc.stderr),
+          ).toBe('');
+          expect(
+            JSON.parse(new TextDecoder().decode(filteredPathExtProc.stdout)),
+          ).toEqual({
+            success: true,
+            output: JSON.stringify({ runtime: 'node', args }),
+          });
+
+          const cwdFallbackProc = Bun.spawnSync(
+            [process.execPath, runnerPath],
+            {
+              cwd: tempDir,
+              env: {
+                ...env,
+                [pathKey]: `${originalPath}${delimiter}`,
+                ALLAGENTS_TEST_COMMAND: 'nested-wrapper',
+              },
+              stdout: 'pipe',
+              stderr: 'pipe',
+            },
+          );
+          const cwdFallbackResult = JSON.parse(
+            new TextDecoder().decode(cwdFallbackProc.stdout),
+          );
+          expect(cwdFallbackProc.exitCode).toBe(0);
+          expect(new TextDecoder().decode(cwdFallbackProc.stderr)).toBe('');
+          expect(cwdFallbackResult).toMatchObject({
+            success: false,
+            output: '',
+          });
+          expect(cwdFallbackResult.error).toContain(
+            'command not found on PATH: nested-wrapper',
+          );
         } finally {
           rmSync(tempDir, { recursive: true, force: true });
         }

--- a/tests/unit/core/native/types.test.ts
+++ b/tests/unit/core/native/types.test.ts
@@ -1,8 +1,103 @@
 import { describe, expect, test } from 'bun:test';
-import { mergeNativeSyncResults } from '../../../../src/core/native/types.js';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { delimiter, join } from 'node:path';
+import { executeCommand, mergeNativeSyncResults } from '../../../../src/core/native/types.js';
 import type { NativeSyncResult } from '../../../../src/core/native/types.js';
 
 describe('native/types', () => {
+  describe('executeCommand', () => {
+    test.skipIf(process.platform !== 'win32')(
+      'preserves npm shim behavior without DEP0190 on Windows',
+      async () => {
+        const tempDir = mkdtempSync(
+          join(tmpdir(), 'allagents-execute-command-'),
+        );
+        const scriptDir = join(tempDir, 'node_modules', 'test-cli');
+        const scriptPath = join(scriptDir, 'print-argv.cjs');
+        const shimPath = join(tempDir, 'argv-recorder.cmd');
+        const runnerPath = join(tempDir, 'run-execute-command.mjs');
+        const args = [
+          'value with spaces',
+          'literal&operator',
+          'literal|pipe',
+          'literal;separator',
+          'literal^caret',
+          'literal%PATH%',
+          'literal"quote',
+          '',
+          'trailing\\',
+          'backslash\\"quote',
+          'literal\r\nnewline',
+        ];
+
+        try {
+          mkdirSync(scriptDir, { recursive: true });
+          writeFileSync(
+            scriptPath,
+            [
+              '#!/usr/bin/env node',
+              "const runtime = typeof Bun === 'undefined' ? 'node' : 'bun';",
+              'const args = process.argv.slice(2);',
+              'process.stdout.write(JSON.stringify({ runtime, args }));',
+            ].join('\n'),
+          );
+          writeFileSync(
+            shimPath,
+            '@ECHO off\r\nnode "%~dp0\\node_modules\\test-cli\\print-argv.cjs" %*\r\n',
+          );
+
+          const bundle = await Bun.build({
+            entrypoints: [
+              join(import.meta.dir, '../../../../src/core/native/types.ts'),
+            ],
+            outdir: tempDir,
+            target: 'node',
+            format: 'esm',
+          });
+          expect(bundle.success).toBe(true);
+          writeFileSync(
+            runnerPath,
+            [
+              "import { executeCommand } from './types.js';",
+              "const args = JSON.parse(process.env.ALLAGENTS_TEST_ARGS ?? '[]');",
+              "const result = await executeCommand('argv-recorder', args);",
+              'process.stdout.write(JSON.stringify(result));',
+            ].join('\n'),
+          );
+
+          const runtimes = [
+            ['node', '--trace-deprecation'],
+            [process.execPath],
+          ];
+          for (const runtime of runtimes) {
+            const proc = Bun.spawnSync([...runtime, runnerPath], {
+              cwd: tempDir,
+              env: {
+                ...process.env,
+                PATH: `${tempDir}${delimiter}${process.env.PATH ?? ''}`,
+                ALLAGENTS_TEST_ARGS: JSON.stringify(args),
+              },
+              stdout: 'pipe',
+              stderr: 'pipe',
+            });
+            const stdout = new TextDecoder().decode(proc.stdout);
+            const stderr = new TextDecoder().decode(proc.stderr);
+
+            expect(proc.exitCode).toBe(0);
+            expect(stderr).toBe('');
+            expect(JSON.parse(stdout)).toEqual({
+              success: true,
+              output: JSON.stringify({ runtime: 'node', args }),
+            });
+          }
+        } finally {
+          rmSync(tempDir, { recursive: true, force: true });
+        }
+      },
+    );
+  });
+
   describe('mergeNativeSyncResults', () => {
     test('merges two results', () => {
       const a: NativeSyncResult = {

--- a/tests/unit/core/native/types.test.ts
+++ b/tests/unit/core/native/types.test.ts
@@ -101,6 +101,7 @@ describe('native/types', () => {
           rmSync(tempDir, { recursive: true, force: true });
         }
       },
+      15_000,
     );
   });
 

--- a/tests/unit/core/native/types.test.ts
+++ b/tests/unit/core/native/types.test.ts
@@ -70,12 +70,18 @@ describe('native/types', () => {
             ['node', '--trace-deprecation'],
             [process.execPath],
           ];
+          const env = { ...process.env };
+          const pathKey =
+            Object.keys(env).find((key) => key.toLowerCase() === 'path') ??
+            'PATH';
+          env[pathKey] =
+            `${tempDir}${delimiter}${env[pathKey] ?? ''}`;
+
           for (const runtime of runtimes) {
             const proc = Bun.spawnSync([...runtime, runnerPath], {
               cwd: tempDir,
               env: {
-                ...process.env,
-                PATH: `${tempDir}${delimiter}${process.env.PATH ?? ''}`,
+                ...env,
                 ALLAGENTS_TEST_ARGS: JSON.stringify(args),
               },
               stdout: 'pipe',


### PR DESCRIPTION
## Summary

Windows native CLI operations now preserve each argument exactly and no longer emit Node's `DEP0190` warning. The shared executor resolves npm `.cmd` shims to their declared Node interpreter before using shell-free process spawning, so globally installed Claude, Copilot, and Codex CLIs still work without exposing MCP URLs, headers, environment values, plugin names, or other dynamic arguments to `cmd.exe` parsing.

The resolver follows the configured `PATH` and `PATHEXT` order, ignores implicit working-directory entries, prefers an npm shim's sibling `node.exe`, and rejects nested batch, PowerShell, or unsupported interpreter paths. A Windows-only CI regression runs the bundled helper from Node and Bun parents and covers argument preservation plus these resolution boundaries.

Workspace setup commands are a separate execution domain: they are explicitly user-authored shell programs, launched only by `workspace setup` as a single shell string. This PR does not route setup commands through the native-client resolver or change their shell syntax and compatibility. The Windows job now exercises the real setup CLI scenarios under `cmd.exe` as well.

Closes #466

## Validation

- `bun run build`
- `bun run typecheck`
- `bun run lint`
- `bun test` - 1,489 pass, 6 skip, 0 fail across 137 files
- `bun run test:e2e` - 130 pass, 4 skip, 0 fail across 12 files
- Local focused suites: `bun test tests/unit/core/native/types.test.ts tests/unit/cli/workspace-setup-command.test.ts` - 10 pass, 1 Windows-only skip, 0 fail
- Windows CI focused suites - 10 pass, 1 intentional POSIX-signal skip, 0 fail; workspace setup contributed 6 pass and native command execution contributed 4 pass
- Built CLI smoke: with an isolated `HOME`, a PATH-local fake `claude`, and a proxied MCP server containing `https://example.test/mcp?one=1&two=2` plus `Authorization=Bearer value & echo injected`, ran `node "$REPO/dist/index.js" --json update --offline`. The CLI exited 0 and delivered the URL and header as unchanged argv elements to `claude mcp add`.
- Setup-command boundary smoke: a single shell command launched with `shell: true` and no separate argv completed with `setup-ok` and no `DEP0190` output under `--trace-deprecation`.
- Built entrypoint smoke: `./dist/index.js --version` returned `1.13.6-next.1`.

The pre-fix native-client shell-mode probe interpreted `SAFE && printf INJECTED` as shell syntax and produced `SAFEINJECTED`; the shell-free native-client path does not.