### PR TITLE
fix(plugin): improve plugin list identity

### DIFF
--- a/.adr-dir
+++ b/.adr-dir
@@ -1,0 +1,1 @@
+docs/decisions

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ clients:
 | `allagents update` | Sync all plugins to workspace |
 | `allagents plugin install <spec>` | Install a plugin |
 | `allagents plugin uninstall <spec>` | Remove a plugin |
-| `allagents plugin list` | List available plugins |
+| `allagents plugin list` | List installed plugins and skills with source, scope, and clients |
 | `allagents skill add <name>` | Add a skill from a repo (plural `skills` alias supported) |
 | `allagents skill list` | List skills and status |
 | `allagents mcp add <name> <commandOrUrl>` | Add an MCP server and sync to clients |

--- a/docs/src/content/docs/docs/reference/cli.mdx
+++ b/docs/src/content/docs/docs/reference/cli.mdx
@@ -152,7 +152,7 @@ The check runs at most once every 24 hours and never blocks startup. Results are
 ## Plugin Commands
 
 ```bash
-allagents plugin list [marketplace]
+allagents plugin list
 allagents plugin validate <path>
 allagents plugin install <plugin> [--skill <name>] [--scope <scope>]
 allagents plugin uninstall <plugin> [--scope <scope>]
@@ -168,20 +168,33 @@ allagents skill update [skill...] [--scope <scope>] [--yes]
 
 ### plugin list
 
-List all installed plugins and skills.
+List installed plugins and standalone skills from user and project scopes.
 
 ```bash
 allagents plugin list
-allagents plugin list [marketplace]  # filter by marketplace name
 ```
 
-Each entry shows a `Type` label of either `plugin` or `skill` (see [`status`](#status) for the classification rule). With `--json`, each entry includes a `kind` field:
+Human-readable output keeps `plugin@marketplace` as the heading for marketplace entries and uses a friendly final-segment name for direct GitHub and local entries. Every entry retains `Type` and `Scope`; `Clients` appears when at least one configured file target or tracked native installation is present. Direct entries also show a compact effective `Source`, including a configured Git ref; marketplace entries omit that redundant line. Native clients are labeled explicitly, such as `native claude`.
+
+With `--json`, each entry includes the friendly `name`, raw configured `spec`, `marketplace`, `scope`, and `kind`, plus `clients` and `nativeClients` when present. Internal effective sources, refs, versions, and status are not exposed:
 
 ```json
 {
-  "plugins": [
-    { "spec": "owner/repo", "scope": "user", "kind": "skill", "fileClients": ["claude"] }
-  ]
+  "success": true,
+  "command": "plugin list",
+  "data": {
+    "plugins": [
+      {
+        "name": "research",
+        "spec": "https://github.com/acme/toolbox/tree/main/plugins/research",
+        "marketplace": "",
+        "scope": "project",
+        "kind": "plugin",
+        "clients": ["codex"]
+      }
+    ],
+    "total": 1
+  }
 }
 ```
 

--- a/src/cli/commands/plugin.ts
+++ b/src/cli/commands/plugin.ts
@@ -18,7 +18,11 @@ import {
   getMarketplaceOverrides,
   getMarketplaceAccessError,
 } from '../../core/marketplace.js';
-import { syncWorkspace, syncUserWorkspace } from '../../core/sync.js';
+import {
+  buildPluginSyncPlans,
+  syncWorkspace,
+  syncUserWorkspace,
+} from '../../core/sync.js';
 import { loadSyncState } from '../../core/sync-state.js';
 import { addPlugin, removePlugin, hasPlugin, ensureWorkspace, addEnabledSkill, extractPluginNames } from '../../core/workspace-modify.js';
 import {
@@ -56,16 +60,16 @@ import { skillsCmd } from './plugin-skills.js';
 import { formatMcpResult, formatNativeResult, buildSyncData, formatPluginArtifacts, formatPluginHeader } from '../format-sync.js';
 import {
   getPluginSource,
-  getPluginClients,
-  getClientTypes,
   type PluginEntry,
-  type WorkspaceConfig,
 } from '../../models/workspace-config.js';
 import { CONFIG_DIR, WORKSPACE_CONFIG_FILE, getHomeDir } from '../../constants.js';
-import { readFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
-import { load } from 'js-yaml';
+import {
+  formatPluginSource,
+  getPluginDisplayName,
+} from '../../utils/plugin-path.js';
+import { parseWorkspaceConfig } from '../../utils/workspace-parser.js';
 
 
 /**
@@ -744,14 +748,22 @@ const pluginListCmd = command({
   args: {},
   handler: async () => {
     try {
-      // Build per-plugin client map from workspace configs
-      // key = "spec:scope" → file-sync client types
+
       const pluginClients = new Map<string, string[]>();
 
-      // Canonical key for deduplication: uses parsed name+marketplace so different
-      // spec formats (e.g., "plugin@owner/repo" vs "plugin@repo") resolve to the same key
-      function canonicalKey(name: string, marketplace: string, scope: string): string {
-        return `${name}:${marketplace}:${scope}`;
+      function sourceKey(
+        source: string,
+        scope: 'user' | 'project',
+      ): string {
+        return `source:${scope}:${source}`;
+      }
+
+      function marketplaceKey(
+        name: string,
+        marketplace: string,
+        scope: 'user' | 'project',
+      ): string {
+        return `marketplace:${scope}:${name}@${marketplace}`;
       }
 
       async function loadConfigClients(
@@ -760,36 +772,36 @@ const pluginListCmd = command({
       ): Promise<void> {
         if (!existsSync(configPath)) return;
         try {
-          const content = await readFile(configPath, 'utf-8');
-          const config = load(content) as WorkspaceConfig;
-          if (!config?.plugins || !config?.clients) return;
-          const defaultClients = getClientTypes(config.clients);
-          for (const entry of config.plugins) {
-            const spec = getPluginSource(entry);
-            const clients = getPluginClients(entry) ?? defaultClients;
-            pluginClients.set(`${spec}:${scope}`, clients);
+          const config = await parseWorkspaceConfig(configPath);
+          const { plans } = buildPluginSyncPlans(
+            config.plugins,
+            config.clients,
+            scope,
+          );
+          for (const plan of plans) {
+            pluginClients.set(sourceKey(plan.source, scope), plan.clients);
           }
-        } catch { /* ignore read/parse errors */ }
+        } catch {
+          // Invalid configs are handled by commands that modify or sync them.
+        }
       }
 
       const userConfigPath = join(getAllagentsDir(), WORKSPACE_CONFIG_FILE);
-      const projectConfigPath = join(process.cwd(), CONFIG_DIR, WORKSPACE_CONFIG_FILE);
+      const projectConfigPath = join(
+        process.cwd(),
+        CONFIG_DIR,
+        WORKSPACE_CONFIG_FILE,
+      );
       const cwdIsHome = isUserConfigPath(process.cwd());
       await loadConfigClients(userConfigPath, 'user');
       if (!cwdIsHome) {
         await loadConfigClients(projectConfigPath, 'project');
       }
 
-      // Get installed marketplace plugins
       const userPlugins = await getInstalledUserPlugins();
       const projectPlugins = await getInstalledProjectPlugins(process.cwd());
       const allInstalled = [...userPlugins, ...projectPlugins];
 
-      // Build a source→kind map so each listed entry can be labelled
-      // 'skill' (root SKILL.md, no skills/ subdir) or 'plugin' (everything
-      // else, including not-yet-resolved sources).
-      // getWorkspaceStatus resolves marketplace specs with { offline: true },
-      // so this is filesystem-only and adds ~2ms per plugin — no network I/O.
       const kindBySource = new Map<string, 'skill' | 'plugin'>();
       try {
         const status = await getWorkspaceStatus(process.cwd());
@@ -800,17 +812,17 @@ const pluginListCmd = command({
           kindBySource.set(p.source, p.kind);
         }
       } catch {
-        // Best-effort: if status lookup fails, fall back to labelling
-        // everything as 'plugin' below.
+        // Best-effort: unresolved sources are plugins.
       }
 
-      // Load native plugins from sync state
-      const userSyncState = await loadSyncState(getAllagentsDir());
-      const projectSyncState = cwdIsHome ? null : await loadSyncState(process.cwd());
+      const userSyncState = await loadSyncState(getHomeDir());
+      const projectSyncState = cwdIsHome
+        ? null
+        : await loadSyncState(process.cwd());
 
-      // Build merged map: key = "name:marketplace:scope" for format-independent dedup
       interface MergedPlugin {
         spec: string;
+        effectiveSpec: string;
         name: string;
         marketplace: string;
         scope: 'user' | 'project';
@@ -820,46 +832,62 @@ const pluginListCmd = command({
       }
       const merged = new Map<string, MergedPlugin>();
 
-      for (const p of allInstalled) {
-        const key = canonicalKey(p.name, p.marketplace, p.scope);
+      for (const plugin of allInstalled) {
+        const key = plugin.marketplace
+          ? marketplaceKey(plugin.name, plugin.marketplace, plugin.scope)
+          : sourceKey(plugin.effectiveSpec, plugin.scope);
+        const clients =
+          pluginClients.get(sourceKey(plugin.effectiveSpec, plugin.scope)) ?? [];
+        const existing = merged.get(key);
+        if (existing) {
+          for (const client of clients) {
+            if (!existing.fileClients.includes(client)) {
+              existing.fileClients.push(client);
+            }
+          }
+          continue;
+        }
         merged.set(key, {
-          spec: p.spec,
-          name: p.name,
-          marketplace: p.marketplace,
-          scope: p.scope,
-          kind: kindBySource.get(p.spec) ?? 'plugin',
-          fileClients: pluginClients.get(`${p.spec}:${p.scope}`) ?? [],
+          spec: plugin.spec,
+          effectiveSpec: plugin.effectiveSpec,
+          name: plugin.name,
+          marketplace: plugin.marketplace,
+          scope: plugin.scope,
+          kind: kindBySource.get(plugin.spec) ?? 'plugin',
+          fileClients: [...clients],
           nativeClients: [],
         });
       }
 
-      // Merge native plugins using the same canonical key
       for (const [state, scope] of [
         [userSyncState, 'user'],
         [projectSyncState, 'project'],
       ] as const) {
-        for (const [client, specs] of Object.entries(state?.nativePlugins ?? {})) {
+        for (const [client, specs] of Object.entries(
+          state?.nativePlugins ?? {},
+        )) {
           for (const spec of specs) {
             const parsed = parsePluginSpec(spec);
             const key = parsed
-              ? canonicalKey(parsed.plugin, parsed.marketplaceName, scope)
-              : `${spec}::${scope}`;
+              ? marketplaceKey(parsed.plugin, parsed.marketplaceName, scope)
+              : sourceKey(spec, scope);
             const existing = merged.get(key);
             if (existing) {
               if (!existing.nativeClients.includes(client)) {
                 existing.nativeClients.push(client);
               }
-            } else {
-              merged.set(key, {
-                spec,
-                name: parsed?.plugin ?? spec,
-                marketplace: parsed?.marketplaceName ?? '',
-                scope,
-                kind: kindBySource.get(spec) ?? 'plugin',
-                fileClients: [],
-                nativeClients: [client],
-              });
+              continue;
             }
+            merged.set(key, {
+              spec,
+              effectiveSpec: spec,
+              name: parsed?.plugin ?? getPluginDisplayName(spec),
+              marketplace: parsed?.marketplaceName ?? '',
+              scope,
+              kind: kindBySource.get(spec) ?? 'plugin',
+              fileClients: [],
+              nativeClients: [client],
+            });
           }
         }
       }
@@ -873,6 +901,7 @@ const pluginListCmd = command({
           data: {
             plugins: plugins.map((p) => ({
               name: p.name,
+              spec: p.spec,
               marketplace: p.marketplace,
               scope: p.scope,
               kind: p.kind,
@@ -899,9 +928,12 @@ const pluginListCmd = command({
 
       console.log('Installed plugins:\n');
       for (const p of plugins) {
-        console.log(`  ❯ ${p.spec}`);
+        console.log(`  ❯ ${p.marketplace ? p.spec : p.name}`);
         console.log(`    Type: ${p.kind}`);
         console.log(`    Scope: ${p.scope}`);
+        if (!p.marketplace) {
+          console.log(`    Source: ${formatPluginSource(p.effectiveSpec)}`);
+        }
 
         const hasClients = p.fileClients.length > 0 || p.nativeClients.length > 0;
         if (hasClients) {

--- a/src/cli/metadata/plugin.ts
+++ b/src/cli/metadata/plugin.ts
@@ -108,9 +108,17 @@ export const pluginListMeta: AgentCommandMeta = {
     'allagents plugin list',
   ],
   expectedOutput:
-    'Lists installed items with type (plugin or skill), marketplace, and scope. If none installed, suggests using marketplace browse.',
+    'Lists marketplace specs and friendly direct-plugin names with type, scope, clients, and a compact direct source. JSON preserves each raw spec. If none are installed, suggests marketplace browse.',
   outputSchema: {
-    plugins: [{ name: 'string', marketplace: 'string', scope: 'string', kind: 'string' }],
+    plugins: [{
+      name: 'string',
+      spec: 'string',
+      marketplace: 'string',
+      scope: 'string',
+      kind: 'string',
+      clients: 'string[] | undefined',
+      nativeClients: 'string[] | undefined',
+    }],
     total: 'number',
   },
 };

--- a/src/core/user-workspace.ts
+++ b/src/core/user-workspace.ts
@@ -1,6 +1,6 @@
 import { existsSync } from 'node:fs';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
-import { basename, join, resolve } from 'node:path';
+import { join, resolve } from 'node:path';
 import { dump, load } from 'js-yaml';
 import { CONFIG_DIR, WORKSPACE_CONFIG_FILE } from '../constants.js';
 import type {
@@ -8,11 +8,14 @@ import type {
   PluginEntry,
   WorkspaceConfig,
 } from '../models/workspace-config.js';
-import { getPluginSource } from '../models/workspace-config.js';
 import {
+  getEffectivePluginSource,
+  getPluginSource,
+} from '../models/workspace-config.js';
+import {
+  getPluginDisplayName,
   isFilesystemRoot,
   isGitHubUrl,
-  parseGitHubUrl,
   validatePluginSource,
   verifyGitHubUrlExists,
 } from '../utils/plugin-path.js';
@@ -799,8 +802,10 @@ export type PluginScope = 'user' | 'project';
  * Information about an installed plugin
  */
 export interface InstalledPluginInfo {
-  /** Full plugin spec (e.g., "plugin@marketplace") */
+  /** Raw plugin spec as written in workspace.yaml */
   spec: string;
+  /** Effective spec used internally for list identity and client lookup */
+  effectiveSpec: string;
   /** Plugin name */
   name: string;
   /** Marketplace name */
@@ -814,35 +819,26 @@ export interface InstalledPluginInfo {
  * Handles plugin@marketplace, GitHub URLs, and local paths.
  */
 function pluginSourceToInfo(
-  plugin: string,
+  pluginEntry: PluginEntry,
   scope: PluginScope,
 ): InstalledPluginInfo {
-  // plugin@marketplace format
-  const parsed = parsePluginSpec(plugin);
+  const spec = getPluginSource(pluginEntry);
+  const effectiveSpec = getEffectivePluginSource(pluginEntry);
+  const parsed = isPluginSpec(spec) ? parsePluginSpec(spec) : null;
   if (parsed) {
     return {
-      spec: plugin,
+      spec,
+      effectiveSpec,
       name: parsed.plugin,
       marketplace: parsed.marketplaceName,
       scope,
     };
   }
 
-  // GitHub URL format
-  if (isGitHubUrl(plugin)) {
-    const ghParsed = parseGitHubUrl(plugin);
-    return {
-      spec: plugin,
-      name: ghParsed?.repo ?? basename(plugin),
-      marketplace: '',
-      scope,
-    };
-  }
-
-  // Local path or other format
   return {
-    spec: plugin,
-    name: basename(plugin),
+    spec,
+    effectiveSpec,
+    name: getPluginDisplayName(spec),
     marketplace: '',
     scope,
   };
@@ -859,8 +855,7 @@ export async function getInstalledUserPlugins(): Promise<
 
   const result: InstalledPluginInfo[] = [];
   for (const pluginEntry of config.plugins) {
-    const plugin = getPluginSource(pluginEntry);
-    result.push(pluginSourceToInfo(plugin, 'user'));
+    result.push(pluginSourceToInfo(pluginEntry, 'user'));
   }
   return result;
 }
@@ -885,8 +880,7 @@ export async function getInstalledProjectPlugins(
 
     const result: InstalledPluginInfo[] = [];
     for (const pluginEntry of config.plugins) {
-      const plugin = getPluginSource(pluginEntry);
-      result.push(pluginSourceToInfo(plugin, 'project'));
+      result.push(pluginSourceToInfo(pluginEntry, 'project'));
     }
     return result;
   } catch {

--- a/src/utils/plugin-path.ts
+++ b/src/utils/plugin-path.ts
@@ -1,5 +1,5 @@
 import { existsSync } from 'node:fs';
-import { isAbsolute, join, parse, resolve } from 'node:path';
+import { basename, isAbsolute, join, parse, resolve } from 'node:path';
 import { getHomeDir } from '../constants.js';
 import {
   GitCloneError,
@@ -335,6 +335,26 @@ export function formatPluginSource(source: string): string {
     ? `${owner}/${repo}`
     : `${owner}/${repo}@${branch}`;
   return subpath ? `${base}/${subpath}` : base;
+}
+
+/**
+ * Derive a friendly plugin name from its source without filesystem or network
+ * access. Marketplace specs remain intact for their caller to parse.
+ */
+export function getPluginDisplayName(source: string): string {
+  const trimmed = source.trim();
+  if (!trimmed) return source;
+  const atIndex = trimmed.lastIndexOf('@');
+  if (atIndex > 0 && !trimmed.slice(0, atIndex).includes('/')) return trimmed;
+
+  if (isGitHubUrl(trimmed)) {
+    const parsed = parseGitHubUrl(trimmed);
+    if (parsed) {
+      return parsed.subpath ? basename(parsed.subpath) : parsed.repo;
+    }
+  }
+
+  return basename(trimmed);
 }
 
 /**

--- a/tests/e2e/plugin-list.test.ts
+++ b/tests/e2e/plugin-list.test.ts
@@ -1,0 +1,230 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+interface CliResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+function runCli(workdir: string, homeDir: string, json = false): CliResult {
+  const cliEntry = join(import.meta.dir, '..', '..', 'src', 'cli', 'index.ts');
+  const args = ['bun', 'run', cliEntry, ...(json ? ['--json'] : []), 'plugin', 'list'];
+  const proc = Bun.spawnSync(args, {
+    cwd: workdir,
+    env: {
+      ...process.env,
+      ALLAGENTS_TEST_HOME: homeDir,
+      HOME: homeDir,
+    },
+    stderr: 'pipe',
+    stdout: 'pipe',
+  });
+
+  return {
+    exitCode: proc.exitCode,
+    stdout: new TextDecoder().decode(proc.stdout),
+    stderr: new TextDecoder().decode(proc.stderr),
+  };
+}
+
+describe('plugin list e2e', () => {
+  let rootDir: string;
+  let workspaceDir: string;
+  let homeDir: string;
+  let projectConfigPath: string;
+  let userConfigPath: string;
+  let projectConfig: string;
+  let userConfig: string;
+
+  beforeEach(() => {
+    rootDir = join(
+      tmpdir(),
+      `allagents-e2e-plugin-list-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    workspaceDir = join(rootDir, 'workspace');
+    homeDir = join(rootDir, 'home');
+    projectConfigPath = join(workspaceDir, '.allagents', 'workspace.yaml');
+    userConfigPath = join(homeDir, '.allagents', 'workspace.yaml');
+
+    mkdirSync(join(workspaceDir, '.allagents'), { recursive: true });
+    mkdirSync(join(homeDir, '.allagents'), { recursive: true });
+
+    projectConfig = `version: 2
+repositories: []
+plugins:
+  - source: https://github.com/acme/toolbox/tree/main/plugins/alpha
+    clients:
+      - codex
+  - source: https://github.com/acme/toolbox/tree/main/plugins/beta
+    clients:
+      - cursor
+  - source: acme/toolbox/plugins/research
+    ref: v1
+    clients:
+      - codex
+  - source: acme/toolbox/plugins/research
+    ref: v2
+    clients:
+      - cursor
+  - acme/toolbox@v3/plugins/inline
+clients:
+  - codex
+`;
+    userConfig = `version: 2
+repositories: []
+plugins:
+  - demo@acme/official
+clients:
+  - claude:native
+`;
+
+    writeFileSync(projectConfigPath, projectConfig, 'utf-8');
+    writeFileSync(userConfigPath, userConfig, 'utf-8');
+    writeFileSync(
+      join(homeDir, '.allagents', 'sync-state.json'),
+      JSON.stringify({
+        version: 1,
+        lastSync: '2026-09-11T00:00:00.000Z',
+        files: {},
+        nativePlugins: { claude: ['demo@official'] },
+      }),
+      'utf-8',
+    );
+  });
+
+  afterEach(() => {
+    rmSync(rootDir, { recursive: true, force: true });
+  });
+
+  test('renders distinct friendly names and compact direct sources', () => {
+    const human = runCli(workspaceDir, homeDir);
+    expect(human.exitCode).toBe(0);
+    expect(human.stderr).toBe('');
+    expect(human.stdout).toContain('❯ alpha');
+    expect(human.stdout).toContain('Source: acme/toolbox/plugins/alpha');
+    expect(human.stdout).toContain('❯ beta');
+    expect(human.stdout).toContain('Source: acme/toolbox/plugins/beta');
+    expect(human.stdout.match(/❯ research/g)).toHaveLength(2);
+    expect(human.stdout).toContain(
+      'Source: acme/toolbox@v1/plugins/research',
+    );
+    expect(human.stdout).toContain(
+      'Source: acme/toolbox@v2/plugins/research',
+    );
+    expect(human.stdout).toContain('❯ inline');
+    expect(human.stdout).toContain(
+      'Source: acme/toolbox@v3/plugins/inline',
+    );
+    expect(human.stdout).toContain('Type: plugin');
+    expect(human.stdout).toContain('Scope: project');
+    expect(human.stdout).toContain('Clients: codex');
+    expect(human.stdout).toContain('Clients: cursor');
+  });
+
+  test('returns corrected names and raw specs without internal fields in JSON', () => {
+    const json = runCli(workspaceDir, homeDir, true);
+    expect(json.exitCode).toBe(0);
+    expect(json.stderr).toBe('');
+    const payload = JSON.parse(json.stdout);
+    expect(
+      payload.data.plugins.filter(
+        (plugin: { scope: string }) => plugin.scope === 'project',
+      ),
+    ).toEqual([
+      {
+        name: 'alpha',
+        spec: 'https://github.com/acme/toolbox/tree/main/plugins/alpha',
+        marketplace: '',
+        scope: 'project',
+        kind: 'plugin',
+        clients: ['codex'],
+      },
+      {
+        name: 'beta',
+        spec: 'https://github.com/acme/toolbox/tree/main/plugins/beta',
+        marketplace: '',
+        scope: 'project',
+        kind: 'plugin',
+        clients: ['cursor'],
+      },
+      {
+        name: 'research',
+        spec: 'acme/toolbox/plugins/research',
+        marketplace: '',
+        scope: 'project',
+        kind: 'plugin',
+        clients: ['codex'],
+      },
+      {
+        name: 'research',
+        spec: 'acme/toolbox/plugins/research',
+        marketplace: '',
+        scope: 'project',
+        kind: 'plugin',
+        clients: ['cursor'],
+      },
+      {
+        name: 'inline',
+        spec: 'acme/toolbox@v3/plugins/inline',
+        marketplace: '',
+        scope: 'project',
+        kind: 'plugin',
+        clients: ['codex'],
+      },
+    ]);
+    expect(payload.data.total).toBe(6);
+  });
+
+  test('merges canonical native state with parsed native client config', () => {
+    const human = runCli(workspaceDir, homeDir);
+    expect(human.exitCode).toBe(0);
+    const demoSection = human.stdout
+      .split('❯ demo@acme/official')[1]
+      ?.split('\n\n')[0];
+    expect(demoSection).toContain('Type: plugin');
+    expect(demoSection).toContain('Scope: user');
+    expect(demoSection).toContain('Clients: native claude');
+    expect(demoSection).not.toContain('claude:native');
+    expect(demoSection).not.toContain('Source:');
+    expect(human.stdout.match(/❯ demo@acme\/official/g)).toHaveLength(1);
+  });
+
+  test('does not report configured native intent without tracked state', () => {
+    rmSync(join(homeDir, '.allagents', 'sync-state.json'));
+
+    const human = runCli(workspaceDir, homeDir);
+    expect(human.exitCode).toBe(0);
+    const demoSection = human.stdout
+      .split('❯ demo@acme/official')[1]
+      ?.split('\n\n')[0];
+    expect(demoSection).toContain('Type: plugin');
+    expect(demoSection).not.toContain('Clients:');
+
+    const json = runCli(workspaceDir, homeDir, true);
+    expect(json.exitCode).toBe(0);
+    const payload = JSON.parse(json.stdout);
+    expect(
+      payload.data.plugins.find(
+        (plugin: { scope: string }) => plugin.scope === 'user',
+      ),
+    ).toEqual({
+      name: 'demo',
+      spec: 'demo@acme/official',
+      marketplace: 'official',
+      scope: 'user',
+      kind: 'plugin',
+    });
+  });
+
+  test('does not modify either workspace config', () => {
+    const human = runCli(workspaceDir, homeDir);
+    const json = runCli(workspaceDir, homeDir, true);
+    expect(human.exitCode).toBe(0);
+    expect(json.exitCode).toBe(0);
+    expect(readFileSync(projectConfigPath, 'utf-8')).toBe(projectConfig);
+    expect(readFileSync(userConfigPath, 'utf-8')).toBe(userConfig);
+  });
+});

--- a/tests/unit/core/user-workspace.test.ts
+++ b/tests/unit/core/user-workspace.test.ts
@@ -337,6 +337,42 @@ describe('user-workspace', () => {
       expect(plugins[2].marketplace).toBe('');
     });
 
+    test('preserves raw sources while deriving names and effective refs', async () => {
+      const workspaceDir = join(tempHome, 'project');
+      const configDir = join(workspaceDir, '.allagents');
+      await mkdir(configDir, { recursive: true });
+      await writeFile(
+        join(configDir, 'workspace.yaml'),
+        `plugins:
+  - source: acme/toolbox/plugins/research
+    ref: v1
+  - source: acme/toolbox/plugins/research
+    ref: v2
+clients:
+  - codex
+`,
+        'utf-8',
+      );
+
+      const plugins = await getInstalledProjectPlugins(workspaceDir);
+      expect(plugins).toEqual([
+        {
+          spec: 'acme/toolbox/plugins/research',
+          effectiveSpec: 'acme/toolbox@v1/plugins/research',
+          name: 'research',
+          marketplace: '',
+          scope: 'project',
+        },
+        {
+          spec: 'acme/toolbox/plugins/research',
+          effectiveSpec: 'acme/toolbox@v2/plugins/research',
+          name: 'research',
+          marketplace: '',
+          scope: 'project',
+        },
+      ]);
+    });
+
     test('returns empty when workspace path is home directory', async () => {
       // Write a config directly to ~/.allagents/workspace.yaml (the user config)
       const configDir = join(tempHome, '.allagents');

--- a/tests/unit/utils/plugin-path.test.ts
+++ b/tests/unit/utils/plugin-path.test.ts
@@ -37,6 +37,7 @@ const {
   validatePluginSource,
   verifyGitHubUrlExists,
   formatPluginSource,
+  getPluginDisplayName,
   isFilesystemRoot,
 } = await import('../../../src/utils/plugin-path.js');
 
@@ -407,6 +408,43 @@ describe('formatPluginSource', () => {
 
   it('passes empty input through', () => {
     expect(formatPluginSource('')).toBe('');
+  });
+});
+
+describe('getPluginDisplayName', () => {
+  it('keeps marketplace specs unchanged', () => {
+    expect(getPluginDisplayName('superpowers@official')).toBe(
+      'superpowers@official',
+    );
+    expect(getPluginDisplayName('demo@acme/official')).toBe(
+      'demo@acme/official',
+    );
+    expect(getPluginDisplayName('demo@acme/official/plugins')).toBe(
+      'demo@acme/official/plugins',
+    );
+  });
+
+  it('uses the final segment for a GitHub subpath', () => {
+    expect(
+      getPluginDisplayName(
+        'https://github.com/acme/toolbox/tree/main/plugins/research',
+      ),
+    ).toBe('research');
+    expect(getPluginDisplayName('acme/toolbox/plugins/review')).toBe('review');
+  });
+
+  it('uses the repository name for a GitHub repository root', () => {
+    expect(getPluginDisplayName('https://github.com/acme/toolbox')).toBe(
+      'toolbox',
+    );
+    expect(getPluginDisplayName('acme/toolbox')).toBe('toolbox');
+  });
+
+  it('uses the basename for a local path', () => {
+    expect(getPluginDisplayName('./plugins/local-tool')).toBe('local-tool');
+    expect(getPluginDisplayName('/opt/plugins/absolute-tool')).toBe(
+      'absolute-tool',
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

- render source-derived plugin names instead of raw GitHub URLs, while retaining a compact `Source` line
- keep direct sources distinct by effective source and merge marketplace/native rows by `plugin@marketplace`
- classify file/native clients through validated workspace config and show native clients only when canonical sync state tracks them
- load user sync state from the correct home root and add the raw `spec` to JSON output
- align CLI metadata, README, reference docs, and process-level regression coverage

## Root cause

`plugin list` printed the persisted source verbatim, reduced deep GitHub URLs to the repository name in JSON, keyed rows by that lossy display identity, read user sync state from `~/.allagents/.allagents/sync-state.json`, and classified raw client shorthand without the workspace schema transforms.

Version and enabled Status remain intentionally absent because AllAgents does not persist truthful plugin-level values for them.

## Verification

```bash
bun run typecheck
bun run lint
bun run build
bun test
bun run test:e2e
bun run docs:build
```

Observed:

- full suite: 1502 passed, 6 skipped, 0 failed
- E2E suite: 135 passed, 4 skipped, 0 failed
- docs: 13 pages built

### Manual built-CLI E2E

```bash
tmp=$(mktemp -d)
mkdir -p "$tmp/home/.allagents" "$tmp/work/.allagents"
printf '%s\n' \
  'version: 2' \
  'repositories: []' \
  'plugins:' \
  '  - https://github.com/EntityProcess/allagents/tree/main/plugins/deepwiki' \
  '  - https://github.com/EntityProcess/allagents/tree/main/plugins/engineering' \
  'clients:' \
  '  - copilot' > "$tmp/work/.allagents/workspace.yaml"
printf '%s\n' \
  'version: 2' \
  'repositories: []' \
  'plugins:' \
  '  - demo@acme/official' \
  'clients:' \
  '  - claude:native' > "$tmp/home/.allagents/workspace.yaml"
printf '%s\n' \
  '{"version":1,"lastSync":"2026-09-11T00:00:00.000Z","files":{},"nativePlugins":{"claude":["demo@official"]}}' \
  > "$tmp/home/.allagents/sync-state.json"
ALLAGENTS_TEST_HOME="$tmp/home" HOME="$tmp/home" NO_COLOR=1 ./dist/index.js plugin list
ALLAGENTS_TEST_HOME="$tmp/home" HOME="$tmp/home" NO_COLOR=1 ./dist/index.js --json plugin list
rm -rf "$tmp"
```

Verified:

- headings are `demo@acme/official`, `deepwiki`, and `engineering`
- direct sources are compact and both sibling subpaths remain listed
- the native-only row reports `Clients: native claude`, without a duplicate file client
- JSON preserves raw source specs and reports corrected names
- both workspace configs remain byte-for-byte unchanged