### PR TITLE
fix(sync): dedupe agent files sharing a name across .md and .agent.md

### DIFF
--- a/src/core/sync.ts
+++ b/src/core/sync.ts
@@ -40,8 +40,12 @@ import {
   type CopyResult,
   findRelocatedGitHubHooks,
   dedupeAgentFilesByName,
+  planAgentOutputs,
   type AgentDedupeRecord,
-  type AgentDedupeSource,
+  type AgentOutput,
+  type AgentOutputConflict,
+  type AgentOutputFailure,
+  type AgentOutputPlan,
 } from './transform.js';
 import { updateAgentFiles } from './workspace-repo.js';
 import {
@@ -333,6 +337,8 @@ export interface SyncOptions {
  * Result of validating a plugin (resolving its path without copying)
  */
 export interface ValidatedPlugin {
+  /** Zero-based position of this plugin in the configured plugin list. */
+  configurationIndex?: number;
   plugin: string;
   resolved: string;
   success: boolean;
@@ -355,6 +361,8 @@ export interface ValidatedPlugin {
 }
 
 export interface PluginSyncPlan {
+  /** Zero-based position of this plugin in the configured plugin list. */
+  configurationIndex: number;
   source: string;
   clients: ClientType[];
   /** Clients that should use native install for this plugin */
@@ -1007,10 +1015,9 @@ export function collectSyncedPaths(
     }
   }
 
-  // Reconcile agent files collapsed by dedupeAgentFilesByName. The .md twin
-  // it removed was reported as 'copied' above (the copy happened before
-  // dedup ran), so drop it from tracking and track the .agent.md survivor
-  // instead — it's the one now on disk representing this agent.
+  // A dedupe record is proof that both exact copies succeeded and the
+  // portable representation was removed. The preferred GitHub path is already
+  // tracked by its own CopyResult; never synthesize ownership here.
   if (agentDedupeRecords && agentDedupeRecords.length > 0) {
     for (const client of clients) {
       const mapping = mappings[client];
@@ -1022,7 +1029,6 @@ export function collectSyncedPaths(
         if (!record.removedPath.startsWith(mapping.agentsPath)) continue;
         const removedIndex = tracked.indexOf(record.removedPath);
         if (removedIndex !== -1) tracked.splice(removedIndex, 1);
-        if (!tracked.includes(record.keptPath)) tracked.push(record.keptPath);
       }
     }
   }
@@ -1069,7 +1075,11 @@ function classifyDeletedPath(
     const rest = path.slice(mapping.agentsPath.length);
     const topLevel = rest.split('/')[0];
     if (!topLevel) return null;
-    return { client, type: 'agent', name: topLevel.replace(/\.md$/i, '') };
+    return {
+      client,
+      type: 'agent',
+      name: topLevel.replace(/(?:\.agent)?\.md$/i, ''),
+    };
   }
 
   return null;
@@ -1091,11 +1101,15 @@ export function computeDeletedArtifacts(
   clients: ClientType[],
   clientMappings: Record<string, ClientMapping>,
   availableSkillNames?: Set<string>,
+  agentDedupeRecords: AgentDedupeRecord[] = [],
 ): DeletedArtifact[] {
   if (!previousState) return [];
 
   const deleted: DeletedArtifact[] = [];
   const seen = new Set<string>();
+  const representationAliases = new Map(
+    agentDedupeRecords.map((record) => [record.removedPath, record.keptPath]),
+  );
 
   for (const client of clients) {
     const oldPaths = previousState.files[client] ?? [];
@@ -1104,7 +1118,13 @@ export function computeDeletedArtifacts(
     if (!mapping) continue;
 
     for (const path of oldPaths) {
-      if (newPaths.has(path)) continue;
+      const replacement = representationAliases.get(path);
+      if (
+        newPaths.has(path) ||
+        (replacement !== undefined && newPaths.has(replacement))
+      ) {
+        continue;
+      }
 
       const artifact = classifyDeletedPath(path, client, mapping);
       if (!artifact) continue;
@@ -1271,7 +1291,7 @@ export function buildPluginSyncPlans(
   const warnings: string[] = [];
   const workspaceClientTypes = getClientTypes(clientEntries);
 
-  const plans = plugins.map((plugin) => {
+  const plans = plugins.map((plugin, configurationIndex) => {
     const source = getEffectivePluginSource(plugin);
     const pluginClientTypes = getPluginClients(plugin) ?? workspaceClientTypes;
 
@@ -1315,6 +1335,7 @@ export function buildPluginSyncPlans(
     const pluginSkillsConfig =
       typeof plugin === 'string' ? undefined : plugin.skills;
     return {
+      configurationIndex,
       source,
       clients: fileClients,
       nativeClients,
@@ -1341,6 +1362,7 @@ export async function validateAllPlugins(
   return Promise.all(
     plans.map(
       async ({
+        configurationIndex,
         source,
         clients,
         nativeClients,
@@ -1350,6 +1372,7 @@ export async function validateAllPlugins(
         const validated = await validatePlugin(source, workspacePath, offline);
         const result: ValidatedPlugin = {
           ...validated,
+          configurationIndex,
           clients,
           nativeClients,
         };
@@ -1390,8 +1413,12 @@ async function copyValidatedPlugin(
   skillNameMap?: Map<string, string>,
   clientMappings?: Record<string, ClientMapping>,
   syncMode: SyncMode = 'symlink',
+  agentOutputs: readonly AgentOutput[] = [],
+  agentConflicts: readonly AgentOutputConflict[] = [],
+  agentFailures: readonly AgentOutputFailure[] = [],
 ): Promise<PluginSyncResult> {
   const copyResults: CopyResult[] = [];
+  let agentOutputsAssigned = false;
   const mappings = resolveClientMappings(
     clients,
     clientMappings ?? CLIENT_MAPPINGS,
@@ -1425,12 +1452,14 @@ async function copyValidatedPlugin(
             ...(skillNameMap && { skillNameMap }),
             clientMappings: mappings,
             syncMode: 'copy',
+            agentOutputs: agentOutputsAssigned ? [] : agentOutputs,
             ...(exclude && { exclude }),
             ...(validatedPlugin.fileArtifacts && {
               fileArtifacts: validatedPlugin.fileArtifacts,
             }),
           },
         );
+        agentOutputsAssigned = true;
         copyResults.push(...results);
       } else {
         // Non-universal client: create symlinks to canonical
@@ -1444,12 +1473,14 @@ async function copyValidatedPlugin(
             clientMappings: mappings,
             syncMode: 'symlink',
             canonicalSkillsPath: CANONICAL_SKILLS_PATH,
+            agentOutputs: agentOutputsAssigned ? [] : agentOutputs,
             ...(exclude && { exclude }),
             ...(validatedPlugin.fileArtifacts && {
               fileArtifacts: validatedPlugin.fileArtifacts,
             }),
           },
         );
+        agentOutputsAssigned = true;
         copyResults.push(...results);
       }
     }
@@ -1470,14 +1501,31 @@ async function copyValidatedPlugin(
           ...(skillNameMap && { skillNameMap }),
           clientMappings: mappings,
           syncMode: 'copy',
+          agentOutputs: agentOutputsAssigned ? [] : agentOutputs,
           ...(exclude && { exclude }),
           ...(validatedPlugin.fileArtifacts && {
             fileArtifacts: validatedPlugin.fileArtifacts,
           }),
         },
       );
+      agentOutputsAssigned = true;
       copyResults.push(...results);
     }
+  }
+  for (const { loser } of agentConflicts) {
+    copyResults.push({
+      source: loser.source,
+      destination: loser.destination,
+      action: 'skipped',
+    });
+  }
+  for (const failure of agentFailures) {
+    copyResults.push({
+      source: failure.source,
+      destination: failure.destination,
+      action: 'failed',
+      error: failure.error,
+    });
   }
 
   const hasFailures = copyResults.some((r) => r.action === 'failed');
@@ -1910,71 +1958,91 @@ async function syncVscodeWorkspaceFile(
   return { config: updatedConfig, hash, repos };
 }
 
-/**
- * Build the `sources` block for sync-state from validated plugins. Each
- * GitHub-shaped source contributes one entry keyed by `owner/repo` (without
- * the `@<ref>` suffix). Local plugins and marketplace specs are skipped since
- * they have no remote ref to record.
- */
-/**
- * Run dedupeAgentFilesByName once per distinct agentsPath among the given
- * clients — copilot and vscode commonly resolve to the same `.github/agents/`
- * directory after resolveClientMappings, so dedupe that directory once rather
- * than once per client sharing it. Emits one sync message per file removed.
- *
- * Only plugins that actually file-copy to a client sharing that agentsPath
- * this sync contribute candidate agent files — see dedupeAgentFilesByName
- * and AgentDedupeSource for why that matters (never touch a file this tool
- * didn't ship).
- */
-async function dedupeAgentFilesForClients(
-  basePath: string,
-  syncClients: ClientType[],
-  resolvedMappings: Record<ClientType, ClientMapping>,
+async function planValidatedPluginAgentOutputs(
   validPlugins: ValidatedPlugin[],
-  dryRun: boolean,
-  messages: string[],
-): Promise<AgentDedupeRecord[]> {
-  const clientsByAgentsPath = new Map<string, ClientType[]>();
-  for (const client of syncClients) {
-    const agentsPath = resolvedMappings[client]?.agentsPath;
-    if (!agentsPath) continue;
-    const group = clientsByAgentsPath.get(agentsPath) ?? [];
-    group.push(client);
-    clientsByAgentsPath.set(agentsPath, group);
-  }
+  basePath: string,
+  mappings: Record<string, ClientMapping>,
+): Promise<AgentOutputPlan> {
+  return planAgentOutputs(
+    validPlugins.map((plugin, validIndex) => ({
+      configurationIndex: plugin.configurationIndex ?? validIndex,
+      plugin: plugin.plugin,
+      pluginPath: plugin.resolved,
+      clients: plugin.clients,
+      ...(plugin.exclude && { exclude: plugin.exclude }),
+      ...(plugin.fileArtifacts && { fileArtifacts: plugin.fileArtifacts }),
+    })),
+    basePath,
+    mappings,
+  );
+}
 
-  const records: AgentDedupeRecord[] = [];
-
-  for (const [agentsPath, clientsInGroup] of clientsByAgentsPath) {
-    const sourcesByPluginPath = new Map<string, AgentDedupeSource>();
-    for (const plugin of validPlugins) {
-      if (!plugin.success) continue;
-      if (!plugin.clients.some((c) => clientsInGroup.includes(c))) continue;
-      sourcesByPluginPath.set(plugin.resolved, {
-        pluginPath: plugin.resolved,
-        ...(plugin.exclude && { exclude: plugin.exclude }),
-        ...(plugin.fileArtifacts && { fileArtifacts: plugin.fileArtifacts }),
-      });
+function appendAgentOutputConflictWarnings(
+  plan: AgentOutputPlan,
+  warnings: string[],
+): void {
+  for (const conflict of plan.conflicts) {
+    if (
+      conflict.winner.configurationIndex === conflict.loser.configurationIndex
+    ) {
+      continue;
     }
-    if (sourcesByPluginPath.size === 0) continue;
-
-    records.push(
-      ...(await dedupeAgentFilesByName(
-        basePath,
-        agentsPath,
-        [...sourcesByPluginPath.values()],
-        { dryRun },
-      )),
+    const subject =
+      conflict.reason === 'logical-name' && conflict.loser.logicalName
+        ? `logical agent '${conflict.loser.logicalName}' at ${conflict.loser.workspaceRelativeDestination}`
+        : `agent output '${conflict.loser.workspaceRelativeDestination}'`;
+    warnings.push(
+      `${conflict.loser.plugin}: skipped ${subject}; first configured provider ${conflict.winner.plugin} owns it`,
     );
   }
+}
 
+function indexAgentOutputPlan(plan: AgentOutputPlan): {
+  outputs: Map<number, AgentOutput[]>;
+  conflicts: Map<number, AgentOutputConflict[]>;
+  failures: Map<number, AgentOutputFailure[]>;
+} {
+  const outputs = new Map<number, AgentOutput[]>();
+  const conflicts = new Map<number, AgentOutputConflict[]>();
+  const failures = new Map<number, AgentOutputFailure[]>();
+  for (const output of plan.outputs) {
+    const owned = outputs.get(output.configurationIndex) ?? [];
+    owned.push(output);
+    outputs.set(output.configurationIndex, owned);
+  }
+  for (const conflict of plan.conflicts) {
+    const lost = conflicts.get(conflict.loser.configurationIndex) ?? [];
+    lost.push(conflict);
+    conflicts.set(conflict.loser.configurationIndex, lost);
+  }
+  for (const failure of plan.failures) {
+    const pluginFailures = failures.get(failure.configurationIndex) ?? [];
+    pluginFailures.push(failure);
+    failures.set(failure.configurationIndex, pluginFailures);
+  }
+  return { outputs, conflicts, failures };
+}
+
+/**
+ * Correlate the immutable plan with exact copy outcomes. Dedupe never
+ * rediscovers source or destination files.
+ */
+async function dedupePlannedAgentFiles(
+  plan: AgentOutputPlan,
+  copyResults: CopyResult[],
+  dryRun: boolean,
+  messages: string[],
+  warnings: string[],
+): Promise<AgentDedupeRecord[]> {
+  const records = await dedupeAgentFilesByName(plan, copyResults, {
+    dryRun,
+    onWarning: (warning) => warnings.push(warning),
+  });
   for (const record of records) {
     messages.push(
       `${dryRun ? 'Would dedupe' : 'Deduped'} agent '${record.name}': removed ${record.removedPath} (kept ${record.keptPath})`,
     );
   }
-
   return records;
 }
 
@@ -2021,36 +2089,17 @@ async function buildSourcesProvenance(
 
 async function persistSyncState(
   workspacePath: string,
-  pluginResults: PluginSyncResult[],
-  workspaceFileResults: CopyResult[],
-  syncClients: ClientType[],
+  syncedFiles: Partial<Record<ClientType, string[]>>,
   nativePluginsByClient: Map<ClientType, string[]>,
   nativeResult: NativeSyncResult | undefined,
   extra?: {
     vscodeState?: { hash: string; repos: string[] };
     codexHooks?: SyncState['codexHooks'];
     mcpTrackedServers?: Partial<Record<string, string[]>>;
-    clientMappings?: Record<ClientType, ClientMapping>;
     skillsIndex?: string[];
     sources?: Record<string, SyncStateSource>;
-    agentDedupeRecords?: AgentDedupeRecord[];
   },
 ): Promise<void> {
-  const allCopyResults: CopyResult[] = [
-    ...pluginResults.flatMap((r) => r.copyResults),
-    ...workspaceFileResults,
-  ];
-
-  const mappings = extra?.clientMappings ?? CLIENT_MAPPINGS;
-  const resolvedMappings = resolveClientMappings(syncClients, mappings);
-  const syncedFiles = collectSyncedPaths(
-    allCopyResults,
-    workspacePath,
-    syncClients,
-    resolvedMappings,
-    extra?.agentDedupeRecords,
-  );
-
   // Build native plugin tracking per-client
   const nativePluginsState: Partial<Record<ClientType, string[]>> = {};
   const installedSet = new Set(
@@ -2279,11 +2328,26 @@ export async function syncWorkspace(
       ? new Set(config.enabledSkills)
       : undefined;
   const allSkills = await sw.measure('skill-collection', () =>
-    collectAllSkills(validPlugins, disabledSkillsSet, enabledSkillsSet, warnings),
+    collectAllSkills(
+      validPlugins,
+      disabledSkillsSet,
+      enabledSkillsSet,
+      warnings,
+    ),
   );
 
   // Build per-plugin skill name maps (handles conflicts automatically)
   const pluginSkillMaps = buildPluginSkillNameMaps(allSkills);
+  const resolvedMappings = resolveClientMappings(syncClients, CLIENT_MAPPINGS);
+  const agentOutputPlan = await sw.measure('agent-output-planning', () =>
+    planValidatedPluginAgentOutputs(
+      validPlugins,
+      workspacePath,
+      CLIENT_MAPPINGS,
+    ),
+  );
+  appendAgentOutputConflictWarnings(agentOutputPlan, warnings);
+  const indexedAgentOutputPlan = indexAgentOutputPlan(agentOutputPlan);
 
   // Step 4: Copy fresh from all validated plugins
   // Pass 2: Copy skills using resolved names
@@ -2293,16 +2357,27 @@ export async function syncWorkspace(
     'plugin-copy',
     () =>
       Promise.all(
-        validPlugins.map(async (validatedPlugin) => {
+        validPlugins.map(async (validatedPlugin, validIndex) => {
           const skillNameMap = pluginSkillMaps.get(validatedPlugin.resolved);
+          const configurationIndex =
+            validatedPlugin.configurationIndex ?? validIndex;
+          const agentOutputs =
+            indexedAgentOutputPlan.outputs.get(configurationIndex) ?? [];
+          const agentConflicts =
+            indexedAgentOutputPlan.conflicts.get(configurationIndex) ?? [];
+          const agentFailures =
+            indexedAgentOutputPlan.failures.get(configurationIndex) ?? [];
           const result = await copyValidatedPlugin(
             validatedPlugin,
             workspacePath,
             validatedPlugin.clients,
             dryRun,
             skillNameMap,
-            undefined, // clientMappings
+            undefined,
             syncMode,
+            agentOutputs,
+            agentConflicts,
+            agentFailures,
           );
           return { ...result, scope: 'project' as const };
         }),
@@ -2327,9 +2402,14 @@ export async function syncWorkspace(
   // This preserves user-owned hooks and replaces only the allagents-managed
   // subset recorded in sync state.
   const codexHookSync = await sw.measure('codex-hooks-sync', async () =>
-    syncCodexProjectHooks(validPlugins, workspacePath, previousState?.codexHooks, {
-      dryRun,
-    }),
+    syncCodexProjectHooks(
+      validPlugins,
+      workspacePath,
+      previousState?.codexHooks,
+      {
+        dryRun,
+      },
+    ),
   );
   warnings.push(...codexHookSync.warnings);
 
@@ -2427,17 +2507,14 @@ export async function syncWorkspace(
 
     // Step 5d: Copy workspace files with GitHub cache
     // Pass repositories and skillsIndexRefs so conditional links are embedded in WORKSPACE-RULES
-    workspaceFileResults.push(...(await copyWorkspaceFiles(
-      sourcePath,
-      workspacePath,
-      filesToCopy,
-      {
+    workspaceFileResults.push(
+      ...(await copyWorkspaceFiles(sourcePath, workspacePath, filesToCopy, {
         dryRun,
         githubCache,
         repositories: config.repositories,
         skillsIndexRefs,
-      },
-    )));
+      })),
+    );
 
     // If claude is a client and CLAUDE.md doesn't exist, copy AGENTS.md to CLAUDE.md
     // Skip when repositories is empty (no agent files should be created)
@@ -2507,11 +2584,6 @@ export async function syncWorkspace(
   warnings.push(...mcpSyncResult.warnings);
   sw.stop('mcp-sync');
 
-  // Count results
-  const { totalCopied, totalFailed, totalSkipped, totalGenerated } =
-    countCopyResults(pluginResults, workspaceFileResults);
-  const hasFailures = pluginResults.some((r) => !r.success) || totalFailed > 0;
-
   // Compute deleted artifacts: compare previous state vs what was just synced
   // Collect all skill names from installed plugins (including disabled) so that
   // skills that are still available but just not synced are not reported as deleted.
@@ -2523,19 +2595,17 @@ export async function syncWorkspace(
     ...pluginResults.flatMap((r) => r.copyResults),
     ...workspaceFileResults,
   ];
-  const resolvedMappings = resolveClientMappings(syncClients, CLIENT_MAPPINGS);
-
-  // Step: collapse agent files that plugins ship twice for the same logical
-  // agent — a portable `<name>.md` and a GitHub Copilot native
-  // `<name>.agent.md`. See dedupeAgentFilesByName for why this happens.
-  const agentDedupeRecords = await dedupeAgentFilesForClients(
-    workspacePath,
-    syncClients,
-    resolvedMappings,
-    validPlugins,
+  const agentDedupeRecords = await dedupePlannedAgentFiles(
+    agentOutputPlan,
+    allCopyResultsForState,
     dryRun,
     messages,
+    warnings,
   );
+  // Count results
+  const { totalCopied, totalFailed, totalSkipped, totalGenerated } =
+    countCopyResults(pluginResults, workspaceFileResults);
+  const hasFailures = pluginResults.some((r) => !r.success) || totalFailed > 0;
 
   const newStatePaths = collectSyncedPaths(
     allCopyResultsForState,
@@ -2550,6 +2620,7 @@ export async function syncWorkspace(
     syncClients,
     resolvedMappings,
     availableSkillNames,
+    agentDedupeRecords,
   );
 
   // Persist sync state (skip in dry-run mode)
@@ -2560,9 +2631,7 @@ export async function syncWorkspace(
     await sw.measure('persist-state', () =>
       persistSyncState(
         workspacePath,
-        pluginResults,
-        workspaceFileResults,
-        syncClients,
+        newStatePaths,
         nativePluginsByClient,
         nativeResult,
         {
@@ -2582,7 +2651,6 @@ export async function syncWorkspace(
             skillsIndex: writtenSkillsIndexFiles,
           }),
           ...(Object.keys(sources).length > 0 && { sources }),
-          ...(agentDedupeRecords.length > 0 && { agentDedupeRecords }),
         },
       ),
     );
@@ -2727,24 +2795,22 @@ export async function syncUserWorkspace(
       selectivePurgeWorkspace(homeDir, previousState, syncClients),
     );
 
-    const relocatedHooks = await sw.measure(
-      'legacy-copilot-hook-scan',
-      () =>
-        findRelocatedGitHubHooks(
-          validPlugins
-            .filter(
-              (plugin) =>
-                plugin.clients.includes('copilot') &&
-                plugin.fileArtifacts?.github !== false,
-            )
-            .map((plugin) => ({
-              pluginPath: plugin.resolved,
-              ...(plugin.exclude && { exclude: plugin.exclude }),
-            })),
-          homeDir,
-          'copilot',
-          { clientMappings: USER_CLIENT_MAPPINGS },
-        ),
+    const relocatedHooks = await sw.measure('legacy-copilot-hook-scan', () =>
+      findRelocatedGitHubHooks(
+        validPlugins
+          .filter(
+            (plugin) =>
+              plugin.clients.includes('copilot') &&
+              plugin.fileArtifacts?.github !== false,
+          )
+          .map((plugin) => ({
+            pluginPath: plugin.resolved,
+            ...(plugin.exclude && { exclude: plugin.exclude }),
+          })),
+        homeDir,
+        'copilot',
+        { clientMappings: USER_CLIENT_MAPPINGS },
+      ),
     );
 
     for (const filePath of relocatedHooks.found) {
@@ -2766,9 +2832,27 @@ export async function syncUserWorkspace(
       ? new Set(config.enabledSkills)
       : undefined;
   const allSkills = await sw.measure('skill-collection', () =>
-    collectAllSkills(validPlugins, disabledSkillsSet, enabledSkillsSet, warnings),
+    collectAllSkills(
+      validPlugins,
+      disabledSkillsSet,
+      enabledSkillsSet,
+      warnings,
+    ),
   );
   const pluginSkillMaps = buildPluginSkillNameMaps(allSkills);
+  const resolvedUserMappings = resolveClientMappings(
+    syncClients,
+    USER_CLIENT_MAPPINGS,
+  );
+  const agentOutputPlan = await sw.measure('agent-output-planning', () =>
+    planValidatedPluginAgentOutputs(
+      validPlugins,
+      homeDir,
+      USER_CLIENT_MAPPINGS,
+    ),
+  );
+  appendAgentOutputConflictWarnings(agentOutputPlan, warnings);
+  const indexedAgentOutputPlan = indexAgentOutputPlan(agentOutputPlan);
 
   // Copy plugins using USER_CLIENT_MAPPINGS
   // Use syncMode from config (defaults to 'symlink')
@@ -2777,9 +2861,16 @@ export async function syncUserWorkspace(
     'plugin-copy',
     () =>
       Promise.all(
-        validPlugins.map(async (vp) => {
+        validPlugins.map(async (vp, validIndex) => {
           const skillNameMap = pluginSkillMaps.get(vp.resolved);
-          const resolvedUserMappings = resolveClientMappings(
+          const configurationIndex = vp.configurationIndex ?? validIndex;
+          const agentOutputs =
+            indexedAgentOutputPlan.outputs.get(configurationIndex) ?? [];
+          const agentConflicts =
+            indexedAgentOutputPlan.conflicts.get(configurationIndex) ?? [];
+          const agentFailures =
+            indexedAgentOutputPlan.failures.get(configurationIndex) ?? [];
+          const pluginMappings = resolveClientMappings(
             vp.clients,
             USER_CLIENT_MAPPINGS,
           );
@@ -2789,18 +2880,17 @@ export async function syncUserWorkspace(
             vp.clients,
             dryRun,
             skillNameMap,
-            resolvedUserMappings,
+            pluginMappings,
             syncMode,
+            agentOutputs,
+            agentConflicts,
+            agentFailures,
           );
           return { ...result, scope: 'user' as const };
         }),
       ),
     `${validPlugins.length} plugin(s)`,
   );
-
-  // Count results
-  const { totalCopied, totalFailed, totalSkipped, totalGenerated } =
-    countCopyResults(pluginResults, []);
 
   // MCP Proxy: prepare transform if configured (user-scoped)
   const userMcpProxyConfig = config.mcpProxy;
@@ -2945,22 +3035,16 @@ export async function syncUserWorkspace(
     warnings,
   );
   const allCopyResultsForState = pluginResults.flatMap((r) => r.copyResults);
-  const resolvedUserMappings = resolveClientMappings(
-    syncClients,
-    USER_CLIENT_MAPPINGS,
-  );
-
-  // Step: collapse agent files that plugins ship twice for the same logical
-  // agent — a portable `<name>.md` and a GitHub Copilot native
-  // `<name>.agent.md`. See dedupeAgentFilesByName for why this happens.
-  const agentDedupeRecords = await dedupeAgentFilesForClients(
-    homeDir,
-    syncClients,
-    resolvedUserMappings,
-    validPlugins,
+  const agentDedupeRecords = await dedupePlannedAgentFiles(
+    agentOutputPlan,
+    allCopyResultsForState,
     dryRun,
     messages,
+    warnings,
   );
+  // Count results
+  const { totalCopied, totalFailed, totalSkipped, totalGenerated } =
+    countCopyResults(pluginResults, []);
 
   const newStatePaths = collectSyncedPaths(
     allCopyResultsForState,
@@ -2975,6 +3059,7 @@ export async function syncUserWorkspace(
     syncClients,
     resolvedUserMappings,
     availableUserSkillNames,
+    agentDedupeRecords,
   );
 
   // Save sync state (including MCP servers and native plugins)
@@ -2984,13 +3069,10 @@ export async function syncUserWorkspace(
     await sw.measure('persist-state', () =>
       persistSyncState(
         homeDir,
-        pluginResults,
-        [],
-        syncClients,
+        newStatePaths,
         nativePluginsByClient,
         nativeResult,
         {
-          clientMappings: USER_CLIENT_MAPPINGS,
           ...(Object.keys(mcpResults).length > 0 && {
             mcpTrackedServers: Object.fromEntries(
               Object.entries(mcpResults).map(([scope, r]) => [
@@ -2999,7 +3081,6 @@ export async function syncUserWorkspace(
               ]),
             ),
           }),
-          ...(agentDedupeRecords.length > 0 && { agentDedupeRecords }),
         },
       ),
     );

--- a/src/core/sync.ts
+++ b/src/core/sync.ts
@@ -41,6 +41,7 @@ import {
   findRelocatedGitHubHooks,
   dedupeAgentFilesByName,
   type AgentDedupeRecord,
+  type AgentDedupeSource,
 } from './transform.js';
 import { updateAgentFiles } from './workspace-repo.js';
 import {
@@ -1920,24 +1921,51 @@ async function syncVscodeWorkspaceFile(
  * clients — copilot and vscode commonly resolve to the same `.github/agents/`
  * directory after resolveClientMappings, so dedupe that directory once rather
  * than once per client sharing it. Emits one sync message per file removed.
+ *
+ * Only plugins that actually file-copy to a client sharing that agentsPath
+ * this sync contribute candidate agent files — see dedupeAgentFilesByName
+ * and AgentDedupeSource for why that matters (never touch a file this tool
+ * didn't ship).
  */
 async function dedupeAgentFilesForClients(
   basePath: string,
   syncClients: ClientType[],
   resolvedMappings: Record<ClientType, ClientMapping>,
+  validPlugins: ValidatedPlugin[],
   dryRun: boolean,
   messages: string[],
 ): Promise<AgentDedupeRecord[]> {
-  const seenAgentsPaths = new Set<string>();
-  const records: AgentDedupeRecord[] = [];
-
+  const clientsByAgentsPath = new Map<string, ClientType[]>();
   for (const client of syncClients) {
     const agentsPath = resolvedMappings[client]?.agentsPath;
-    if (!agentsPath || seenAgentsPaths.has(agentsPath)) continue;
-    seenAgentsPaths.add(agentsPath);
+    if (!agentsPath) continue;
+    const group = clientsByAgentsPath.get(agentsPath) ?? [];
+    group.push(client);
+    clientsByAgentsPath.set(agentsPath, group);
+  }
+
+  const records: AgentDedupeRecord[] = [];
+
+  for (const [agentsPath, clientsInGroup] of clientsByAgentsPath) {
+    const sourcesByPluginPath = new Map<string, AgentDedupeSource>();
+    for (const plugin of validPlugins) {
+      if (!plugin.success) continue;
+      if (!plugin.clients.some((c) => clientsInGroup.includes(c))) continue;
+      sourcesByPluginPath.set(plugin.resolved, {
+        pluginPath: plugin.resolved,
+        ...(plugin.exclude && { exclude: plugin.exclude }),
+        ...(plugin.fileArtifacts && { fileArtifacts: plugin.fileArtifacts }),
+      });
+    }
+    if (sourcesByPluginPath.size === 0) continue;
 
     records.push(
-      ...(await dedupeAgentFilesByName(basePath, agentsPath, { dryRun })),
+      ...(await dedupeAgentFilesByName(
+        basePath,
+        agentsPath,
+        [...sourcesByPluginPath.values()],
+        { dryRun },
+      )),
     );
   }
 
@@ -2504,6 +2532,7 @@ export async function syncWorkspace(
     workspacePath,
     syncClients,
     resolvedMappings,
+    validPlugins,
     dryRun,
     messages,
   );
@@ -2928,6 +2957,7 @@ export async function syncUserWorkspace(
     homeDir,
     syncClients,
     resolvedUserMappings,
+    validPlugins,
     dryRun,
     messages,
   );

--- a/src/core/sync.ts
+++ b/src/core/sync.ts
@@ -39,6 +39,8 @@ import {
   collectPluginSkills,
   type CopyResult,
   findRelocatedGitHubHooks,
+  dedupeAgentFilesByName,
+  type AgentDedupeRecord,
 } from './transform.js';
 import { updateAgentFiles } from './workspace-repo.js';
 import {
@@ -949,6 +951,7 @@ export function collectSyncedPaths(
   workspacePath: string,
   clients: ClientType[],
   clientMappings?: Record<string, ClientMapping>,
+  agentDedupeRecords?: AgentDedupeRecord[],
 ): Partial<Record<ClientType, string[]>> {
   const result: Partial<Record<ClientType, string[]>> = {};
   const mappings = clientMappings ?? CLIENT_MAPPINGS;
@@ -999,6 +1002,26 @@ export function collectSyncedPaths(
       ) {
         result[client]?.push(relativePath);
         // Don't break - continue checking other clients that might share this path
+      }
+    }
+  }
+
+  // Reconcile agent files collapsed by dedupeAgentFilesByName. The .md twin
+  // it removed was reported as 'copied' above (the copy happened before
+  // dedup ran), so drop it from tracking and track the .agent.md survivor
+  // instead — it's the one now on disk representing this agent.
+  if (agentDedupeRecords && agentDedupeRecords.length > 0) {
+    for (const client of clients) {
+      const mapping = mappings[client];
+      if (!mapping.agentsPath) continue;
+      const tracked = result[client];
+      if (!tracked) continue;
+
+      for (const record of agentDedupeRecords) {
+        if (!record.removedPath.startsWith(mapping.agentsPath)) continue;
+        const removedIndex = tracked.indexOf(record.removedPath);
+        if (removedIndex !== -1) tracked.splice(removedIndex, 1);
+        if (!tracked.includes(record.keptPath)) tracked.push(record.keptPath);
       }
     }
   }
@@ -1892,6 +1915,41 @@ async function syncVscodeWorkspaceFile(
  * the `@<ref>` suffix). Local plugins and marketplace specs are skipped since
  * they have no remote ref to record.
  */
+/**
+ * Run dedupeAgentFilesByName once per distinct agentsPath among the given
+ * clients — copilot and vscode commonly resolve to the same `.github/agents/`
+ * directory after resolveClientMappings, so dedupe that directory once rather
+ * than once per client sharing it. Emits one sync message per file removed.
+ */
+async function dedupeAgentFilesForClients(
+  basePath: string,
+  syncClients: ClientType[],
+  resolvedMappings: Record<ClientType, ClientMapping>,
+  dryRun: boolean,
+  messages: string[],
+): Promise<AgentDedupeRecord[]> {
+  const seenAgentsPaths = new Set<string>();
+  const records: AgentDedupeRecord[] = [];
+
+  for (const client of syncClients) {
+    const agentsPath = resolvedMappings[client]?.agentsPath;
+    if (!agentsPath || seenAgentsPaths.has(agentsPath)) continue;
+    seenAgentsPaths.add(agentsPath);
+
+    records.push(
+      ...(await dedupeAgentFilesByName(basePath, agentsPath, { dryRun })),
+    );
+  }
+
+  for (const record of records) {
+    messages.push(
+      `${dryRun ? 'Would dedupe' : 'Deduped'} agent '${record.name}': removed ${record.removedPath} (kept ${record.keptPath})`,
+    );
+  }
+
+  return records;
+}
+
 async function buildSourcesProvenance(
   validatedPlugins: ValidatedPlugin[],
   pluginEntries: PluginEntry[],
@@ -1947,6 +2005,7 @@ async function persistSyncState(
     clientMappings?: Record<ClientType, ClientMapping>;
     skillsIndex?: string[];
     sources?: Record<string, SyncStateSource>;
+    agentDedupeRecords?: AgentDedupeRecord[];
   },
 ): Promise<void> {
   const allCopyResults: CopyResult[] = [
@@ -1961,6 +2020,7 @@ async function persistSyncState(
     workspacePath,
     syncClients,
     resolvedMappings,
+    extra?.agentDedupeRecords,
   );
 
   // Build native plugin tracking per-client
@@ -2436,11 +2496,24 @@ export async function syncWorkspace(
     ...workspaceFileResults,
   ];
   const resolvedMappings = resolveClientMappings(syncClients, CLIENT_MAPPINGS);
+
+  // Step: collapse agent files that plugins ship twice for the same logical
+  // agent — a portable `<name>.md` and a GitHub Copilot native
+  // `<name>.agent.md`. See dedupeAgentFilesByName for why this happens.
+  const agentDedupeRecords = await dedupeAgentFilesForClients(
+    workspacePath,
+    syncClients,
+    resolvedMappings,
+    dryRun,
+    messages,
+  );
+
   const newStatePaths = collectSyncedPaths(
     allCopyResultsForState,
     workspacePath,
     syncClients,
     resolvedMappings,
+    agentDedupeRecords,
   );
   const deletedArtifacts = computeDeletedArtifacts(
     previousState,
@@ -2480,6 +2553,7 @@ export async function syncWorkspace(
             skillsIndex: writtenSkillsIndexFiles,
           }),
           ...(Object.keys(sources).length > 0 && { sources }),
+          ...(agentDedupeRecords.length > 0 && { agentDedupeRecords }),
         },
       ),
     );
@@ -2846,11 +2920,24 @@ export async function syncUserWorkspace(
     syncClients,
     USER_CLIENT_MAPPINGS,
   );
+
+  // Step: collapse agent files that plugins ship twice for the same logical
+  // agent — a portable `<name>.md` and a GitHub Copilot native
+  // `<name>.agent.md`. See dedupeAgentFilesByName for why this happens.
+  const agentDedupeRecords = await dedupeAgentFilesForClients(
+    homeDir,
+    syncClients,
+    resolvedUserMappings,
+    dryRun,
+    messages,
+  );
+
   const newStatePaths = collectSyncedPaths(
     allCopyResultsForState,
     homeDir,
     syncClients,
     resolvedUserMappings,
+    agentDedupeRecords,
   );
   const deletedArtifacts = computeDeletedArtifacts(
     previousState,
@@ -2882,6 +2969,7 @@ export async function syncUserWorkspace(
               ]),
             ),
           }),
+          ...(agentDedupeRecords.length > 0 && { agentDedupeRecords }),
         },
       ),
     );

--- a/src/core/transform.ts
+++ b/src/core/transform.ts
@@ -753,6 +753,70 @@ export interface AgentDedupeRecord {
 }
 
 /**
+ * A plugin whose agent files should be considered for {@link dedupeAgentFilesByName}.
+ * Mirrors the same source directories and exclude/fileArtifacts gating that
+ * `copyAgents` and `copyGitHubContent` themselves use, so dedup only ever
+ * reasons about files this sync actually asked those two functions to write —
+ * never a file a user created by hand in the destination directory.
+ */
+export interface AgentDedupeSource {
+  pluginPath: string;
+  exclude?: string[];
+  /** Same flags copyPluginToWorkspace checks before calling copyAgents/copyGitHubContent. */
+  fileArtifacts?: MarketplaceFileArtifacts;
+}
+
+interface AgentFileCandidate {
+  fileName: string;
+  /** Absolute path to the plugin's source file, read for its `name:` frontmatter. */
+  sourcePath: string;
+}
+
+/**
+ * Enumerate the destination filenames dedupeAgentFilesByName is allowed to
+ * touch for one agentsPath: the union, across the given plugins, of their
+ * root `agents/*.md` (copyAgents' source) and `.github/agents/*.md` (part of
+ * copyGitHubContent's source), filtered the same way those copy functions
+ * filter them. Later plugins win a filename collision, matching copy order.
+ */
+async function collectAgentFileCandidates(
+  sources: AgentDedupeSource[],
+): Promise<Map<string, AgentFileCandidate>> {
+  const candidates = new Map<string, AgentFileCandidate>();
+
+  for (const { pluginPath, exclude, fileArtifacts } of sources) {
+    const includeAgents = fileArtifacts?.agents ?? true;
+    const includeGithub = fileArtifacts?.github ?? true;
+
+    if (includeAgents) {
+      const rootDir = join(pluginPath, 'agents');
+      if (existsSync(rootDir)) {
+        for (const file of await readdir(rootDir)) {
+          if (!file.endsWith('.md')) continue;
+          const sourcePath = join(rootDir, file);
+          if (isExcluded(pluginPath, sourcePath, exclude)) continue;
+          candidates.set(file, { fileName: file, sourcePath });
+        }
+      }
+    }
+
+    if (includeGithub) {
+      const githubAgentsDir = join(pluginPath, '.github', 'agents');
+      if (existsSync(githubAgentsDir)) {
+        for (const file of await readdir(githubAgentsDir)) {
+          if (!file.endsWith('.md')) continue;
+          const sourcePath = join(githubAgentsDir, file);
+          if (isExcluded(pluginPath, sourcePath, exclude)) continue;
+          candidates.set(file, { fileName: file, sourcePath });
+        }
+      }
+    }
+  }
+
+  return candidates;
+}
+
+/**
  * Collapse agent definitions that ship under two filenames for the same
  * logical agent: a portable `<name>.md` (copied from a plugin's root
  * `agents/` directory) and a GitHub Copilot native `<name>.agent.md` (copied
@@ -771,23 +835,29 @@ export interface AgentDedupeRecord {
  * the same directory declares the identical name. A file with no readable
  * `name:` frontmatter is left alone.
  *
+ * Only filenames that `sources` actually ship this sync are ever considered —
+ * frontmatter is read from each plugin's own source file, not the destination
+ * directory — so a file a user created by hand in `agentsPath` is never
+ * touched, and dry-run reports exactly what a real sync would do even before
+ * any destination file exists on disk.
+ *
  * @param workspacePath - Path to workspace directory (or home directory for user scope)
  * @param agentsPath - Client's agents directory, relative to workspacePath (e.g. `.github/agents/`)
+ * @param sources - Plugins whose agent files are eligible for this agentsPath
  * @param options - `dryRun` reports what would be removed without deleting anything
  * @returns One record per `.md` file removed (or that would be removed)
  */
 export async function dedupeAgentFilesByName(
   workspacePath: string,
   agentsPath: string,
+  sources: AgentDedupeSource[],
   options: { dryRun?: boolean } = {},
 ): Promise<AgentDedupeRecord[]> {
   const { dryRun = false } = options;
-  const dir = join(workspacePath, agentsPath);
-  if (!existsSync(dir)) {
+  const candidates = await collectAgentFileCandidates(sources);
+  if (candidates.size === 0) {
     return [];
   }
-
-  const files = (await readdir(dir)).filter((f) => f.endsWith('.md'));
 
   interface NameGroup {
     agentMdFile?: string;
@@ -795,10 +865,10 @@ export async function dedupeAgentFilesByName(
   }
   const groups = new Map<string, NameGroup>();
 
-  for (const file of files) {
+  for (const { fileName, sourcePath } of candidates.values()) {
     let name: unknown;
     try {
-      const content = await readFile(join(dir, file), 'utf-8');
+      const content = await readFile(sourcePath, 'utf-8');
       name = matter(content).data?.name;
     } catch {
       continue; // Unreadable or unparsable — leave it alone.
@@ -806,21 +876,23 @@ export async function dedupeAgentFilesByName(
     if (typeof name !== 'string' || name.length === 0) continue;
 
     const group = groups.get(name) ?? { plainMdFiles: [] };
-    if (file.endsWith('.agent.md')) {
-      group.agentMdFile = file;
+    if (fileName.endsWith('.agent.md')) {
+      group.agentMdFile = fileName;
     } else {
-      group.plainMdFiles.push(file);
+      group.plainMdFiles.push(fileName);
     }
     groups.set(name, group);
   }
 
+  const dir = join(workspacePath, agentsPath);
   const records: AgentDedupeRecord[] = [];
   for (const [name, group] of groups) {
     if (!group.agentMdFile || group.plainMdFiles.length === 0) continue;
 
     for (const file of group.plainMdFiles) {
-      if (!dryRun) {
-        await unlink(join(dir, file));
+      const destPath = join(dir, file);
+      if (!dryRun && existsSync(destPath)) {
+        await unlink(destPath);
       }
       records.push({
         name,

--- a/src/core/transform.ts
+++ b/src/core/transform.ts
@@ -5,9 +5,11 @@ import {
   mkdir,
   readFile,
   readdir,
+  unlink,
   writeFile,
 } from 'node:fs/promises';
 import { basename, dirname, join, relative } from 'node:path';
+import matter from 'gray-matter';
 import micromatch from 'micromatch';
 import {
   type SkillsIndexRef,
@@ -735,6 +737,100 @@ export async function copyAgents(
     });
 
   return Promise.all(copyPromises);
+}
+
+/**
+ * One agent that was collapsed by {@link dedupeAgentFilesByName}: a `.md` file
+ * removed in favor of a `.agent.md` file declaring the same frontmatter `name`.
+ */
+export interface AgentDedupeRecord {
+  /** Value of the shared `name:` frontmatter field. */
+  name: string;
+  /** Workspace-relative path of the file that was removed (or would be, in dry-run). */
+  removedPath: string;
+  /** Workspace-relative path of the `.agent.md` file that was kept. */
+  keptPath: string;
+}
+
+/**
+ * Collapse agent definitions that ship under two filenames for the same
+ * logical agent: a portable `<name>.md` (copied from a plugin's root
+ * `agents/` directory) and a GitHub Copilot native `<name>.agent.md` (copied
+ * from a plugin's own `.github/agents/` directory). Both can land in the same
+ * `agentsPath` directory when a plugin provides both, because each copy step
+ * matches on the full destination filename, not on the agent's identity.
+ *
+ * GitHub Copilot's documented custom-agent convention is `.github/agents/*.agent.md`.
+ * Older Copilot Chat builds also load plain `.md` files there, so shipping
+ * both produces two entries for one agent in the picker until every client
+ * catches up to the stricter convention. Keeping `.agent.md` and removing the
+ * `.md` twin works everywhere.
+ *
+ * Agents are matched by their `name:` frontmatter field (not by filename
+ * stem), so a plain `.md` file only gets removed when a `.agent.md` file in
+ * the same directory declares the identical name. A file with no readable
+ * `name:` frontmatter is left alone.
+ *
+ * @param workspacePath - Path to workspace directory (or home directory for user scope)
+ * @param agentsPath - Client's agents directory, relative to workspacePath (e.g. `.github/agents/`)
+ * @param options - `dryRun` reports what would be removed without deleting anything
+ * @returns One record per `.md` file removed (or that would be removed)
+ */
+export async function dedupeAgentFilesByName(
+  workspacePath: string,
+  agentsPath: string,
+  options: { dryRun?: boolean } = {},
+): Promise<AgentDedupeRecord[]> {
+  const { dryRun = false } = options;
+  const dir = join(workspacePath, agentsPath);
+  if (!existsSync(dir)) {
+    return [];
+  }
+
+  const files = (await readdir(dir)).filter((f) => f.endsWith('.md'));
+
+  interface NameGroup {
+    agentMdFile?: string;
+    plainMdFiles: string[];
+  }
+  const groups = new Map<string, NameGroup>();
+
+  for (const file of files) {
+    let name: unknown;
+    try {
+      const content = await readFile(join(dir, file), 'utf-8');
+      name = matter(content).data?.name;
+    } catch {
+      continue; // Unreadable or unparsable — leave it alone.
+    }
+    if (typeof name !== 'string' || name.length === 0) continue;
+
+    const group = groups.get(name) ?? { plainMdFiles: [] };
+    if (file.endsWith('.agent.md')) {
+      group.agentMdFile = file;
+    } else {
+      group.plainMdFiles.push(file);
+    }
+    groups.set(name, group);
+  }
+
+  const records: AgentDedupeRecord[] = [];
+  for (const [name, group] of groups) {
+    if (!group.agentMdFile || group.plainMdFiles.length === 0) continue;
+
+    for (const file of group.plainMdFiles) {
+      if (!dryRun) {
+        await unlink(join(dir, file));
+      }
+      records.push({
+        name,
+        removedPath: `${agentsPath}${file}`,
+        keptPath: `${agentsPath}${group.agentMdFile}`,
+      });
+    }
+  }
+
+  return records;
 }
 
 /**

--- a/src/core/transform.ts
+++ b/src/core/transform.ts
@@ -19,6 +19,7 @@ import {
 import {
   CLIENT_MAPPINGS,
   isUniversalClient,
+  resolveClientMappings,
 } from '../models/client-mapping.js';
 import type { ClientMapping } from '../models/client-mapping.js';
 import type { MarketplaceFileArtifacts } from '../models/marketplace-manifest.js';
@@ -84,7 +85,7 @@ export async function ensureWorkspaceRules(
 export interface CopyResult {
   source: string;
   destination: string;
-  action: 'copied' | 'skipped' | 'failed' | 'generated';
+  action: 'copied' | 'deduped' | 'skipped' | 'failed' | 'generated';
   error?: string;
 }
 
@@ -739,165 +740,384 @@ export async function copyAgents(
   return Promise.all(copyPromises);
 }
 
+export type AgentOutputRoute = 'portable' | 'github';
+
 /**
- * One agent that was collapsed by {@link dedupeAgentFilesByName}: a `.md` file
- * removed in favor of a `.agent.md` file declaring the same frontmatter `name`.
+ * One immutable copy decision for an agent file. The destination and logical
+ * ownership recorded here are reused by copying, dedupe, warnings, and state.
+ */
+export interface AgentOutput {
+  readonly configurationIndex: number;
+  readonly plugin: string;
+  readonly pluginPath: string;
+  readonly source: string;
+  readonly destination: string;
+  readonly workspaceRelativeDestination: string;
+  readonly route: AgentOutputRoute;
+  readonly logicalName?: string;
+  readonly clients: readonly ClientType[];
+}
+
+export interface AgentOutputConflict {
+  readonly reason: 'destination' | 'logical-name';
+  readonly winner: AgentOutput;
+  readonly loser: AgentOutput;
+}
+
+export interface AgentOutputFailure {
+  readonly configurationIndex: number;
+  readonly plugin: string;
+  readonly source: string;
+  readonly destination: string;
+  readonly error: string;
+}
+
+export interface AgentOutputPlan {
+  readonly outputs: readonly AgentOutput[];
+  readonly conflicts: readonly AgentOutputConflict[];
+  readonly failures: readonly AgentOutputFailure[];
+}
+
+export interface AgentOutputPlugin {
+  readonly configurationIndex: number;
+  readonly plugin: string;
+  readonly pluginPath: string;
+  readonly clients: readonly ClientType[];
+  readonly exclude?: string[];
+  readonly fileArtifacts?: MarketplaceFileArtifacts;
+}
+
+/**
+ * One agent representation removed after both planned representations copied
+ * successfully.
  */
 export interface AgentDedupeRecord {
-  /** Value of the shared `name:` frontmatter field. */
   name: string;
-  /** Workspace-relative path of the file that was removed (or would be, in dry-run). */
   removedPath: string;
-  /** Workspace-relative path of the `.agent.md` file that was kept. */
   keptPath: string;
 }
 
-/**
- * A plugin whose agent files should be considered for {@link dedupeAgentFilesByName}.
- * Mirrors the same source directories and exclude/fileArtifacts gating that
- * `copyAgents` and `copyGitHubContent` themselves use, so dedup only ever
- * reasons about files this sync actually asked those two functions to write —
- * never a file a user created by hand in the destination directory.
- */
-export interface AgentDedupeSource {
-  pluginPath: string;
-  exclude?: string[];
-  /** Same flags copyPluginToWorkspace checks before calling copyAgents/copyGitHubContent. */
-  fileArtifacts?: MarketplaceFileArtifacts;
+function workspaceRelativePath(
+  workspacePath: string,
+  destination: string,
+): string {
+  return relative(workspacePath, destination).replaceAll('\\', '/');
 }
 
-interface AgentFileCandidate {
-  fileName: string;
-  /** Absolute path to the plugin's source file, read for its `name:` frontmatter. */
-  sourcePath: string;
+async function readAgentLogicalName(
+  source: string,
+  cache: Map<string, string | undefined>,
+): Promise<string | undefined> {
+  if (cache.has(source)) return cache.get(source);
+
+  let name: string | undefined;
+  try {
+    const parsed = matter(await readFile(source, 'utf-8')).data?.name;
+    if (typeof parsed === 'string' && parsed.length > 0) name = parsed;
+  } catch {
+    // An unreadable name cannot participate in logical-name ownership.
+  }
+  cache.set(source, name);
+  return name;
+}
+
+function mergeAgentOutputConsumer(
+  candidates: Map<string, AgentOutput>,
+  candidate: AgentOutput,
+): void {
+  const key = `${candidate.route}\0${candidate.source}\0${candidate.destination}`;
+  const existing = candidates.get(key);
+  if (existing) {
+    const additionalClients = candidate.clients.filter(
+      (client) => !existing.clients.includes(client),
+    );
+    if (additionalClients.length > 0) {
+      candidates.set(key, {
+        ...existing,
+        clients: [...existing.clients, ...additionalClients],
+      });
+    }
+    return;
+  }
+  candidates.set(key, candidate);
+}
+
+async function readAgentSourceEntries(
+  sourceDir: string,
+): Promise<{ files: Dirent[]; error?: string }> {
+  if (!existsSync(sourceDir)) return { files: [] };
+  try {
+    return {
+      files: (await readdir(sourceDir, { withFileTypes: true }))
+        .filter((entry) => !entry.isDirectory() && entry.name.endsWith('.md'))
+        .sort((a, b) => a.name.localeCompare(b.name)),
+    };
+  } catch (error) {
+    return {
+      files: [],
+      error: error instanceof Error ? error.message : 'Unknown error',
+    };
+  }
 }
 
 /**
- * Enumerate the destination filenames dedupeAgentFilesByName is allowed to
- * touch for one agentsPath: the union, across the given plugins, of their
- * root `agents/*.md` (copyAgents' source) and `.github/agents/*.md` (part of
- * copyGitHubContent's source), filtered the same way those copy functions
- * filter them. Later plugins win a filename collision, matching copy order.
+ * Discover agent sources once and choose their owners before plugin copying
+ * starts. Plugins are considered in configuration order; an earlier valid
+ * plugin owns both exact destinations and logical names within a physical
+ * agents directory. Within one plugin, a GitHub-route source owns an exact
+ * destination over its portable counterpart.
  */
-async function collectAgentFileCandidates(
-  sources: AgentDedupeSource[],
-): Promise<Map<string, AgentFileCandidate>> {
-  const candidates = new Map<string, AgentFileCandidate>();
+export async function planAgentOutputs(
+  plugins: readonly AgentOutputPlugin[],
+  workspacePath: string,
+  clientMappings: Record<string, ClientMapping> = CLIENT_MAPPINGS,
+): Promise<AgentOutputPlan> {
+  const outputs: AgentOutput[] = [];
+  const conflicts: AgentOutputConflict[] = [];
+  const failures: AgentOutputFailure[] = [];
+  const destinationOwners = new Map<string, AgentOutput>();
+  const logicalNameOwners = new Map<string, AgentOutput>();
+  const logicalNames = new Map<string, string | undefined>();
 
-  for (const { pluginPath, exclude, fileArtifacts } of sources) {
-    const includeAgents = fileArtifacts?.agents ?? true;
-    const includeGithub = fileArtifacts?.github ?? true;
+  const orderedPlugins = plugins
+    .map((plugin, order) => ({ plugin, order }))
+    .sort(
+      (a, b) =>
+        a.plugin.configurationIndex - b.plugin.configurationIndex ||
+        a.order - b.order,
+    );
 
-    if (includeAgents) {
-      const rootDir = join(pluginPath, 'agents');
-      if (existsSync(rootDir)) {
-        for (const file of await readdir(rootDir)) {
-          if (!file.endsWith('.md')) continue;
-          const sourcePath = join(rootDir, file);
-          if (isExcluded(pluginPath, sourcePath, exclude)) continue;
-          candidates.set(file, { fileName: file, sourcePath });
+  for (const { plugin } of orderedPlugins) {
+    const resolvedPluginMappings = resolveClientMappings(
+      [...plugin.clients],
+      clientMappings,
+    );
+    const candidates = new Map<string, AgentOutput>();
+    const includePortable = plugin.fileArtifacts?.agents ?? true;
+    const includeGithub = plugin.fileArtifacts?.github ?? true;
+
+    const portableDestination = plugin.clients
+      .map((client) => resolvedPluginMappings[client]?.agentsPath)
+      .find((path): path is string => path !== undefined);
+    if (includePortable && portableDestination) {
+      const sourceDir = join(plugin.pluginPath, 'agents');
+      const sourceEntries = await readAgentSourceEntries(sourceDir);
+      if (sourceEntries.error) {
+        failures.push({
+          configurationIndex: plugin.configurationIndex,
+          plugin: plugin.plugin,
+          source: sourceDir,
+          destination: join(workspacePath, portableDestination),
+          error: sourceEntries.error,
+        });
+      }
+      for (const entry of sourceEntries.files) {
+        const source = join(sourceDir, entry.name);
+        if (isExcluded(plugin.pluginPath, source, plugin.exclude)) continue;
+        const logicalName = await readAgentLogicalName(source, logicalNames);
+        for (const client of plugin.clients) {
+          const agentsPath = resolvedPluginMappings[client]?.agentsPath;
+          if (!agentsPath) continue;
+          const destination = join(workspacePath, agentsPath, entry.name);
+          mergeAgentOutputConsumer(candidates, {
+            configurationIndex: plugin.configurationIndex,
+            plugin: plugin.plugin,
+            pluginPath: plugin.pluginPath,
+            source,
+            destination,
+            workspaceRelativeDestination: workspaceRelativePath(
+              workspacePath,
+              destination,
+            ),
+            route: 'portable',
+            ...(logicalName && { logicalName }),
+            clients: [client],
+          });
         }
       }
     }
 
-    if (includeGithub) {
-      const githubAgentsDir = join(pluginPath, '.github', 'agents');
-      if (existsSync(githubAgentsDir)) {
-        for (const file of await readdir(githubAgentsDir)) {
-          if (!file.endsWith('.md')) continue;
-          const sourcePath = join(githubAgentsDir, file);
-          if (isExcluded(pluginPath, sourcePath, exclude)) continue;
-          candidates.set(file, { fileName: file, sourcePath });
+    const githubDestination = plugin.clients
+      .map((client) => resolvedPluginMappings[client]?.githubPath)
+      .find((path): path is string => path !== undefined);
+    if (includeGithub && githubDestination) {
+      const sourceDir = join(plugin.pluginPath, '.github', 'agents');
+      const sourceEntries = await readAgentSourceEntries(sourceDir);
+      if (sourceEntries.error) {
+        failures.push({
+          configurationIndex: plugin.configurationIndex,
+          plugin: plugin.plugin,
+          source: sourceDir,
+          destination: join(workspacePath, githubDestination, 'agents'),
+          error: sourceEntries.error,
+        });
+      }
+      for (const entry of sourceEntries.files) {
+        const source = join(sourceDir, entry.name);
+        if (isExcluded(plugin.pluginPath, source, plugin.exclude)) continue;
+        const logicalName = await readAgentLogicalName(source, logicalNames);
+        for (const client of plugin.clients) {
+          const githubPath = resolvedPluginMappings[client]?.githubPath;
+          if (!githubPath) continue;
+          const destination = join(
+            workspacePath,
+            githubPath,
+            'agents',
+            entry.name,
+          );
+          mergeAgentOutputConsumer(candidates, {
+            configurationIndex: plugin.configurationIndex,
+            plugin: plugin.plugin,
+            pluginPath: plugin.pluginPath,
+            source,
+            destination,
+            workspaceRelativeDestination: workspaceRelativePath(
+              workspacePath,
+              destination,
+            ),
+            route: 'github',
+            ...(logicalName && { logicalName }),
+            clients: [client],
+          });
         }
+      }
+    }
+
+    const candidatesByDestination = new Map<string, AgentOutput[]>();
+    for (const candidate of candidates.values()) {
+      const grouped = candidatesByDestination.get(candidate.destination) ?? [];
+      grouped.push(candidate);
+      candidatesByDestination.set(candidate.destination, grouped);
+    }
+
+    const pluginWinners: AgentOutput[] = [];
+    for (const sameDestination of candidatesByDestination.values()) {
+      const preferred =
+        sameDestination.find((candidate) => candidate.route === 'github') ??
+        sameDestination[0];
+      if (!preferred) continue;
+      const consumingClients = [
+        ...new Set(sameDestination.flatMap((candidate) => candidate.clients)),
+      ];
+      const winner: AgentOutput = {
+        ...preferred,
+        clients: consumingClients,
+      };
+      pluginWinners.push(winner);
+      for (const loser of sameDestination) {
+        if (loser !== preferred) {
+          conflicts.push({ reason: 'destination', winner, loser });
+        }
+      }
+    }
+
+    for (const candidate of pluginWinners) {
+      const destinationWinner = destinationOwners.get(candidate.destination);
+      const logicalKey = candidate.logicalName
+        ? `${dirname(candidate.destination)}\0${candidate.logicalName}`
+        : undefined;
+      const logicalWinner = logicalKey
+        ? logicalNameOwners.get(logicalKey)
+        : undefined;
+      const destinationConflict =
+        destinationWinner &&
+        destinationWinner.configurationIndex !== candidate.configurationIndex
+          ? destinationWinner
+          : undefined;
+      const logicalConflict =
+        logicalWinner &&
+        logicalWinner.configurationIndex !== candidate.configurationIndex
+          ? logicalWinner
+          : undefined;
+      const winner = destinationConflict ?? logicalConflict;
+
+      if (winner) {
+        conflicts.push({
+          reason: destinationWinner === winner ? 'destination' : 'logical-name',
+          winner,
+          loser: candidate,
+        });
+        continue;
+      }
+
+      outputs.push(candidate);
+      if (!destinationWinner) {
+        destinationOwners.set(candidate.destination, candidate);
+      }
+      if (logicalKey && !logicalWinner) {
+        logicalNameOwners.set(logicalKey, candidate);
       }
     }
   }
 
-  return candidates;
+  return { outputs, conflicts, failures };
 }
 
 /**
- * Collapse agent definitions that ship under two filenames for the same
- * logical agent: a portable `<name>.md` (copied from a plugin's root
- * `agents/` directory) and a GitHub Copilot native `<name>.agent.md` (copied
- * from a plugin's own `.github/agents/` directory). Both can land in the same
- * `agentsPath` directory when a plugin provides both, because each copy step
- * matches on the full destination filename, not on the agent's identity.
- *
- * GitHub Copilot's documented custom-agent convention is `.github/agents/*.agent.md`.
- * Older Copilot Chat builds also load plain `.md` files there, so shipping
- * both produces two entries for one agent in the picker until every client
- * catches up to the stricter convention. Keeping `.agent.md` and removing the
- * `.md` twin works everywhere.
- *
- * Agents are matched by their `name:` frontmatter field (not by filename
- * stem), so a plain `.md` file only gets removed when a `.agent.md` file in
- * the same directory declares the identical name. A file with no readable
- * `name:` frontmatter is left alone.
- *
- * Only filenames that `sources` actually ship this sync are ever considered —
- * frontmatter is read from each plugin's own source file, not the destination
- * directory — so a file a user created by hand in `agentsPath` is never
- * touched, and dry-run reports exactly what a real sync would do even before
- * any destination file exists on disk.
- *
- * @param workspacePath - Path to workspace directory (or home directory for user scope)
- * @param agentsPath - Client's agents directory, relative to workspacePath (e.g. `.github/agents/`)
- * @param sources - Plugins whose agent files are eligible for this agentsPath
- * @param options - `dryRun` reports what would be removed without deleting anything
- * @returns One record per `.md` file removed (or that would be removed)
+ * Collapse a same-plugin portable/GitHub pair only when both exact planned
+ * copies succeeded. No source or destination discovery occurs here.
  */
 export async function dedupeAgentFilesByName(
-  workspacePath: string,
-  agentsPath: string,
-  sources: AgentDedupeSource[],
-  options: { dryRun?: boolean } = {},
+  plan: AgentOutputPlan,
+  copyResults: readonly CopyResult[],
+  options: { dryRun?: boolean; onWarning?: (warning: string) => void } = {},
 ): Promise<AgentDedupeRecord[]> {
-  const { dryRun = false } = options;
-  const candidates = await collectAgentFileCandidates(sources);
-  if (candidates.size === 0) {
-    return [];
+  const copiedOutputs = new Map(
+    copyResults
+      .filter((result) => result.action === 'copied')
+      .map((result) => [`${result.source}\0${result.destination}`, result]),
+  );
+  const groups = new Map<
+    string,
+    { portable: AgentOutput[]; github: AgentOutput[] }
+  >();
+  for (const output of plan.outputs) {
+    if (!output.logicalName) continue;
+    const key = `${dirname(output.destination)}\0${output.logicalName}`;
+    const group = groups.get(key) ?? { portable: [], github: [] };
+    group[output.route].push(output);
+    groups.set(key, group);
   }
 
-  interface NameGroup {
-    agentMdFile?: string;
-    plainMdFiles: string[];
-  }
-  const groups = new Map<string, NameGroup>();
-
-  for (const { fileName, sourcePath } of candidates.values()) {
-    let name: unknown;
-    try {
-      const content = await readFile(sourcePath, 'utf-8');
-      name = matter(content).data?.name;
-    } catch {
-      continue; // Unreadable or unparsable — leave it alone.
-    }
-    if (typeof name !== 'string' || name.length === 0) continue;
-
-    const group = groups.get(name) ?? { plainMdFiles: [] };
-    if (fileName.endsWith('.agent.md')) {
-      group.agentMdFile = fileName;
-    } else {
-      group.plainMdFiles.push(fileName);
-    }
-    groups.set(name, group);
-  }
-
-  const dir = join(workspacePath, agentsPath);
   const records: AgentDedupeRecord[] = [];
-  for (const [name, group] of groups) {
-    if (!group.agentMdFile || group.plainMdFiles.length === 0) continue;
+  for (const group of groups.values()) {
+    const github = group.github.find(
+      (output) =>
+        output.destination.endsWith('.agent.md') &&
+        copiedOutputs.has(`${output.source}\0${output.destination}`),
+    );
+    if (!github) continue;
 
-    for (const file of group.plainMdFiles) {
-      const destPath = join(dir, file);
-      if (!dryRun && existsSync(destPath)) {
-        await unlink(destPath);
+    for (const portable of group.portable) {
+      const name = portable.logicalName;
+      const portableResult = copiedOutputs.get(
+        `${portable.source}\0${portable.destination}`,
+      );
+      if (portable.destination.endsWith('.agent.md')) continue;
+      if (
+        !name ||
+        portable.configurationIndex !== github.configurationIndex ||
+        !portableResult
+      ) {
+        continue;
       }
+      if (!options.dryRun) {
+        try {
+          await unlink(portable.destination);
+        } catch (error) {
+          const message =
+            error instanceof Error ? error.message : 'Unknown error';
+          options.onWarning?.(
+            `Could not dedupe agent '${name}': failed to remove ${portable.workspaceRelativeDestination}: ${message}`,
+          );
+          continue;
+        }
+      }
+      portableResult.action = 'deduped';
       records.push({
         name,
-        removedPath: `${agentsPath}${file}`,
-        keptPath: `${agentsPath}${group.agentMdFile}`,
+        removedPath: portable.workspaceRelativeDestination,
+        keptPath: github.workspaceRelativeDestination,
       });
     }
   }
@@ -914,6 +1134,11 @@ export interface GitHubCopyOptions extends CopyOptions {
    * Used when skills are renamed due to conflicts, so links can be adjusted accordingly.
    */
   skillNameMap?: Map<string, string>;
+  /**
+   * Preselected GitHub-route agent files. When omitted, this direct caller gets
+   * a one-plugin plan so aggregate GitHub copying still cannot bypass planning.
+   */
+  agentOutputs?: readonly AgentOutput[];
 }
 
 function relocatesGitHubContent(mapping: ClientMapping): boolean {
@@ -925,6 +1150,9 @@ function githubContentExcludes(
   exclude?: string[],
 ): string[] | undefined {
   const effectiveExclude = [...(exclude ?? [])];
+  // Top-level Markdown definitions use the per-file ownership plan. Nested
+  // files and companion assets retain the aggregate copy behavior.
+  effectiveExclude.push('.github/agents/*.md', '.github/agents/.*.md');
 
   // Copilot plugin package metadata is used to discover a native plugin, but
   // it has no runtime role after file-mode content is overlaid into a project.
@@ -1031,6 +1259,17 @@ export async function findRelocatedGitHubHooks(
  * Recursively process a directory, copying files and adjusting links in markdown.
  * Single-pass approach: read source → transform if markdown → write to dest.
  */
+function isMalformedGitHubAgentsEntry(
+  pluginPath: string,
+  sourcePath: string,
+  entry: Dirent,
+): boolean {
+  return (
+    !entry.isDirectory() &&
+    relative(pluginPath, sourcePath).replaceAll('\\', '/') === '.github/agents'
+  );
+}
+
 async function copyAndAdjustDirectory(
   sourceDir: string,
   destDir: string,
@@ -1046,6 +1285,7 @@ async function copyAndAdjustDirectory(
   for (const entry of entries) {
     const sourcePath = join(sourceDir, entry.name);
     const destPath = join(destDir, entry.name);
+    if (isMalformedGitHubAgentsEntry(pluginPath, sourcePath, entry)) continue;
 
     if (isExcluded(pluginPath, sourcePath, exclude)) {
       continue;
@@ -1085,15 +1325,82 @@ async function copyAndAdjustDirectory(
   }
 }
 
+async function hasIncludedFiles(
+  sourceDir: string,
+  pluginPath: string,
+  exclude?: string[],
+): Promise<boolean> {
+  for (const entry of await readdir(sourceDir, { withFileTypes: true })) {
+    const sourcePath = join(sourceDir, entry.name);
+    if (isMalformedGitHubAgentsEntry(pluginPath, sourcePath, entry)) continue;
+    if (isExcluded(pluginPath, sourcePath, exclude)) continue;
+    if (!entry.isDirectory()) return true;
+    if (await hasIncludedFiles(sourcePath, pluginPath, exclude)) return true;
+  }
+  return false;
+}
+
+interface PlannedAgentCopyOptions {
+  dryRun: boolean;
+  clientMappings: Record<string, ClientMapping>;
+  skillNameMap?: Map<string, string>;
+}
+
+async function copyPlannedAgentOutputs(
+  outputs: readonly AgentOutput[],
+  options: PlannedAgentCopyOptions,
+): Promise<CopyResult[]> {
+  return Promise.all(
+    outputs.map(async (output): Promise<CopyResult> => {
+      if (options.dryRun) {
+        return {
+          source: output.source,
+          destination: output.destination,
+          action: 'copied',
+        };
+      }
+
+      try {
+        await mkdir(dirname(output.destination), { recursive: true });
+        let content = await readFile(output.source, 'utf-8');
+        if (output.route === 'github') {
+          const sourceRelativeToGithub = relative(
+            join(output.pluginPath, '.github'),
+            output.source,
+          ).replaceAll('\\', '/');
+          const firstClient = output.clients[0];
+          const skillsPath = firstClient
+            ? (options.clientMappings[firstClient]?.skillsPath ?? '')
+            : '';
+          content = adjustLinksInContent(content, sourceRelativeToGithub, {
+            ...(options.skillNameMap && {
+              skillNameMap: options.skillNameMap,
+            }),
+            workspaceSkillsPath: skillsPath,
+          });
+        }
+        await writeFile(output.destination, content, 'utf-8');
+        return {
+          source: output.source,
+          destination: output.destination,
+          action: 'copied',
+        };
+      } catch (error) {
+        return {
+          source: output.source,
+          destination: output.destination,
+          action: 'failed',
+          error: error instanceof Error ? error.message : 'Unknown error',
+        };
+      }
+    }),
+  );
+}
+
 /**
- * Copy GitHub-specific content from plugin to workspace
- * This includes prompts (.github/prompts/), copilot-instructions.md, and other GitHub Copilot files.
- * Adjusts relative links in markdown files to point to correct workspace locations.
- * @param pluginPath - Path to plugin directory
- * @param workspacePath - Path to workspace directory
- * @param client - Target client type
- * @param options - Copy options (dryRun, skillNameMap)
- * @returns Array of copy results
+ * Copy GitHub-specific content from plugin to workspace. Agent files always
+ * use the immutable per-file ownership plan and are excluded from aggregate
+ * traversal.
  */
 export async function copyGitHubContent(
   pluginPath: string,
@@ -1103,46 +1410,52 @@ export async function copyGitHubContent(
 ): Promise<CopyResult[]> {
   const { dryRun = false, skillNameMap } = options;
   const mapping = getMapping(client, options);
+  const mappings = options.clientMappings ?? CLIENT_MAPPINGS;
   const results: CopyResult[] = [];
-
-  // Skip if client doesn't support GitHub content
   if (!mapping.githubPath) {
-    return results;
+    return options.agentOutputs
+      ? copyPlannedAgentOutputs(options.agentOutputs, {
+          dryRun,
+          clientMappings: mappings,
+          ...(skillNameMap && { skillNameMap }),
+        })
+      : results;
   }
 
   const sourceDir = join(pluginPath, '.github');
-  if (!existsSync(sourceDir)) {
-    return results;
+  if (!existsSync(sourceDir)) return results;
+
+  let agentOutputs = options.agentOutputs;
+  let planningFailures: readonly AgentOutputFailure[] = [];
+  if (agentOutputs === undefined) {
+    const directPlan = await planAgentOutputs(
+      [
+        {
+          configurationIndex: 0,
+          plugin: basename(pluginPath),
+          pluginPath,
+          clients: [client],
+          ...(options.exclude && { exclude: options.exclude }),
+        },
+      ],
+      workspacePath,
+      mappings,
+    );
+    agentOutputs = directPlan.outputs.filter(
+      (output) => output.route === 'github',
+    );
+    planningFailures = directPlan.failures;
   }
 
   const destDir = join(workspacePath, mapping.githubPath);
   const effectiveExclude = githubContentExcludes(mapping, options.exclude);
-
-  if (dryRun) {
-    results.push({ source: sourceDir, destination: destDir, action: 'copied' });
-    return results;
-  }
-
+  let hasAggregateContent = false;
   try {
-    // Single-pass: copy files and adjust markdown links in one traversal
-    if (
-      mapping.skillsPath ||
-      (effectiveExclude && effectiveExclude.length > 0)
-    ) {
-      await copyAndAdjustDirectory(
-        sourceDir,
-        destDir,
-        sourceDir,
-        pluginPath,
-        mapping.skillsPath ?? '',
-        skillNameMap,
-        effectiveExclude,
-      );
-    } else {
-      // No skills path and no excludes - just copy without adjustment
-      await cp(sourceDir, destDir, { recursive: true });
-    }
-    results.push({ source: sourceDir, destination: destDir, action: 'copied' });
+    hasAggregateContent = await hasIncludedFiles(
+      sourceDir,
+      pluginPath,
+      effectiveExclude,
+    );
   } catch (error) {
     results.push({
       source: sourceDir,
@@ -1151,7 +1464,55 @@ export async function copyGitHubContent(
       error: error instanceof Error ? error.message : 'Unknown error',
     });
   }
+  if (hasAggregateContent) {
+    if (dryRun) {
+      results.push({
+        source: sourceDir,
+        destination: destDir,
+        action: 'copied',
+      });
+    } else {
+      try {
+        await copyAndAdjustDirectory(
+          sourceDir,
+          destDir,
+          sourceDir,
+          pluginPath,
+          mapping.skillsPath,
+          skillNameMap,
+          effectiveExclude,
+        );
+        results.push({
+          source: sourceDir,
+          destination: destDir,
+          action: 'copied',
+        });
+      } catch (error) {
+        results.push({
+          source: sourceDir,
+          destination: destDir,
+          action: 'failed',
+          error: error instanceof Error ? error.message : 'Unknown error',
+        });
+      }
+    }
+  }
 
+  results.push(
+    ...(await copyPlannedAgentOutputs(agentOutputs, {
+      dryRun,
+      clientMappings: mappings,
+      ...(skillNameMap && { skillNameMap }),
+    })),
+  );
+  results.push(
+    ...planningFailures.map((failure) => ({
+      source: failure.source,
+      destination: failure.destination,
+      action: 'failed' as const,
+      error: failure.error,
+    })),
+  );
   return results;
 }
 
@@ -1180,6 +1541,12 @@ export interface PluginCopyOptions extends CopyOptions {
    * Required when syncMode is 'symlink' and client is non-universal.
    */
   canonicalSkillsPath?: string;
+  /**
+   * Agent files already selected by a scope-level plan. Undefined creates a
+   * one-plugin plan for direct callers; an empty array intentionally copies no
+   * agent files.
+   */
+  agentOutputs?: readonly AgentOutput[];
 }
 
 /**
@@ -1202,13 +1569,37 @@ export async function copyPluginToWorkspace(
     syncMode,
     canonicalSkillsPath,
     fileArtifacts,
+    agentOutputs: providedAgentOutputs,
     ...baseOptions
   } = options;
   const shouldCopy = (artifact: keyof MarketplaceFileArtifacts): boolean =>
     fileArtifacts?.[artifact] ?? true;
+  const mappings = options.clientMappings ?? CLIENT_MAPPINGS;
 
-  // Phase 1: Copy root-level artifacts in parallel
-  const [commandResults, skillResults, hookResults, agentResults] =
+  let agentOutputs = providedAgentOutputs;
+  let directConflicts: readonly AgentOutputConflict[] = [];
+  let directFailures: readonly AgentOutputFailure[] = [];
+  if (agentOutputs === undefined) {
+    const directPlan = await planAgentOutputs(
+      [
+        {
+          configurationIndex: 0,
+          plugin: basename(pluginPath),
+          pluginPath,
+          clients: [client],
+          ...(baseOptions.exclude && { exclude: baseOptions.exclude }),
+          ...(fileArtifacts && { fileArtifacts }),
+        },
+      ],
+      workspacePath,
+      mappings,
+    );
+    agentOutputs = directPlan.outputs;
+    directConflicts = directPlan.conflicts;
+    directFailures = directPlan.failures;
+  }
+
+  const [commandResults, skillResults, hookResults, portableAgentResults] =
     await Promise.all([
       shouldCopy('commands')
         ? copyCommands(pluginPath, workspacePath, client, baseOptions)
@@ -1224,25 +1615,47 @@ export async function copyPluginToWorkspace(
       shouldCopy('hooks')
         ? copyHooks(pluginPath, workspacePath, client, baseOptions)
         : [],
-      shouldCopy('agents')
-        ? copyAgents(pluginPath, workspacePath, client, baseOptions)
-        : [],
+      copyPlannedAgentOutputs(
+        agentOutputs.filter((output) => output.route === 'portable'),
+        {
+          dryRun: baseOptions.dryRun ?? false,
+          clientMappings: mappings,
+          ...(skillNameMap && { skillNameMap }),
+        },
+      ),
     ]);
 
-  // Phase 2: Copy .github/ content — overrides root-level on name conflicts
   const githubResults = shouldCopy('github')
     ? await copyGitHubContent(pluginPath, workspacePath, client, {
         ...baseOptions,
         ...(skillNameMap && { skillNameMap }),
+        agentOutputs: agentOutputs.filter(
+          (output) => output.route === 'github',
+        ),
       })
     : [];
+  const skippedAgentResults: CopyResult[] = directConflicts.map(
+    ({ loser }) => ({
+      source: loser.source,
+      destination: loser.destination,
+      action: 'skipped',
+    }),
+  );
+  const failedAgentResults: CopyResult[] = directFailures.map((failure) => ({
+    source: failure.source,
+    destination: failure.destination,
+    action: 'failed',
+    error: failure.error,
+  }));
 
   return [
     ...commandResults,
     ...skillResults,
     ...hookResults,
-    ...agentResults,
+    ...portableAgentResults,
     ...githubResults,
+    ...skippedAgentResults,
+    ...failedAgentResults,
   ];
 }
 

--- a/tests/unit/core/agent-dedupe-state.test.ts
+++ b/tests/unit/core/agent-dedupe-state.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from 'bun:test';
+import { collectSyncedPaths } from '../../../src/core/sync.js';
+import { CLIENT_MAPPINGS } from '../../../src/models/client-mapping.js';
+import type { CopyResult } from '../../../src/core/transform.js';
+import type { AgentDedupeRecord } from '../../../src/core/transform.js';
+
+describe('collectSyncedPaths with agentDedupeRecords', () => {
+  it('drops the removed .md path and tracks the kept .agent.md path instead', () => {
+    const workspacePath = '/workspace';
+    const copyResults: CopyResult[] = [
+      {
+        source: '/plugin/agents/cw-reviewer.md',
+        destination: '/workspace/.github/agents/cw-reviewer.md',
+        action: 'copied',
+      },
+    ];
+    const agentDedupeRecords: AgentDedupeRecord[] = [
+      {
+        name: 'cw-reviewer',
+        removedPath: '.github/agents/cw-reviewer.md',
+        keptPath: '.github/agents/cw-reviewer.agent.md',
+      },
+    ];
+
+    const result = collectSyncedPaths(
+      copyResults,
+      workspacePath,
+      ['copilot'],
+      CLIENT_MAPPINGS,
+      agentDedupeRecords,
+    );
+
+    expect(result.copilot).toEqual(['.github/agents/cw-reviewer.agent.md']);
+  });
+
+  it('applies the same record to every client sharing that agentsPath', () => {
+    const workspacePath = '/workspace';
+    const copyResults: CopyResult[] = [
+      {
+        source: '/plugin/agents/cw-reviewer.md',
+        destination: '/workspace/.github/agents/cw-reviewer.md',
+        action: 'copied',
+      },
+    ];
+    const agentDedupeRecords: AgentDedupeRecord[] = [
+      {
+        name: 'cw-reviewer',
+        removedPath: '.github/agents/cw-reviewer.md',
+        keptPath: '.github/agents/cw-reviewer.agent.md',
+      },
+    ];
+    // After resolveClientMappings, vscode shares copilot's agentsPath — simulate
+    // that here directly so this test doesn't depend on that resolution step.
+    const mappings = {
+      ...CLIENT_MAPPINGS,
+      vscode: CLIENT_MAPPINGS.copilot,
+    };
+
+    const result = collectSyncedPaths(
+      copyResults,
+      workspacePath,
+      ['copilot', 'vscode'],
+      mappings,
+      agentDedupeRecords,
+    );
+
+    expect(result.copilot).toEqual(['.github/agents/cw-reviewer.agent.md']);
+    expect(result.vscode).toEqual(['.github/agents/cw-reviewer.agent.md']);
+  });
+
+  it('is a no-op for clients whose agentsPath does not match the record', () => {
+    const workspacePath = '/workspace';
+    const copyResults: CopyResult[] = [
+      {
+        source: '/plugin/agents/cw-reviewer.md',
+        destination: '/home/.claude/agents/cw-reviewer.md',
+        action: 'copied',
+      },
+    ];
+    const agentDedupeRecords: AgentDedupeRecord[] = [
+      {
+        name: 'cw-reviewer',
+        removedPath: '.github/agents/cw-reviewer.md',
+        keptPath: '.github/agents/cw-reviewer.agent.md',
+      },
+    ];
+
+    const result = collectSyncedPaths(
+      copyResults,
+      '/home',
+      ['claude'],
+      CLIENT_MAPPINGS,
+      agentDedupeRecords,
+    );
+
+    // claude's own copy of the richer .md agent is untouched by a dedup record
+    // that only concerns the .github/agents/ directory.
+    expect(result.claude).toEqual(['.claude/agents/cw-reviewer.md']);
+  });
+
+  it('does not duplicate the kept path if it was already tracked', () => {
+    const workspacePath = '/workspace';
+    const copyResults: CopyResult[] = [
+      {
+        source: '/plugin/agents/cw-reviewer.md',
+        destination: '/workspace/.github/agents/cw-reviewer.md',
+        action: 'copied',
+      },
+      {
+        source: '/plugin/.github/agents/cw-reviewer.agent.md',
+        destination: '/workspace/.github/agents/cw-reviewer.agent.md',
+        action: 'copied',
+      },
+    ];
+    const agentDedupeRecords: AgentDedupeRecord[] = [
+      {
+        name: 'cw-reviewer',
+        removedPath: '.github/agents/cw-reviewer.md',
+        keptPath: '.github/agents/cw-reviewer.agent.md',
+      },
+    ];
+
+    const result = collectSyncedPaths(
+      copyResults,
+      workspacePath,
+      ['copilot'],
+      CLIENT_MAPPINGS,
+      agentDedupeRecords,
+    );
+
+    expect(result.copilot).toEqual(['.github/agents/cw-reviewer.agent.md']);
+  });
+});

--- a/tests/unit/core/agent-dedupe-state.test.ts
+++ b/tests/unit/core/agent-dedupe-state.test.ts
@@ -1,105 +1,19 @@
-import { describe, it, expect } from 'bun:test';
+import { describe, expect, it } from 'bun:test';
 import { collectSyncedPaths } from '../../../src/core/sync.js';
 import { CLIENT_MAPPINGS } from '../../../src/models/client-mapping.js';
-import type { CopyResult } from '../../../src/core/transform.js';
-import type { AgentDedupeRecord } from '../../../src/core/transform.js';
+import type {
+  AgentDedupeRecord,
+  CopyResult,
+} from '../../../src/core/transform.js';
 
-describe('collectSyncedPaths with agentDedupeRecords', () => {
-  it('drops the removed .md path and tracks the kept .agent.md path instead', () => {
-    const workspacePath = '/workspace';
-    const copyResults: CopyResult[] = [
-      {
-        source: '/plugin/agents/cw-reviewer.md',
-        destination: '/workspace/.github/agents/cw-reviewer.md',
-        action: 'copied',
-      },
-    ];
-    const agentDedupeRecords: AgentDedupeRecord[] = [
-      {
-        name: 'cw-reviewer',
-        removedPath: '.github/agents/cw-reviewer.md',
-        keptPath: '.github/agents/cw-reviewer.agent.md',
-      },
-    ];
+const deduped: AgentDedupeRecord = {
+  name: 'cw-reviewer',
+  removedPath: '.github/agents/cw-reviewer.md',
+  keptPath: '.github/agents/cw-reviewer.agent.md',
+};
 
-    const result = collectSyncedPaths(
-      copyResults,
-      workspacePath,
-      ['copilot'],
-      CLIENT_MAPPINGS,
-      agentDedupeRecords,
-    );
-
-    expect(result.copilot).toEqual(['.github/agents/cw-reviewer.agent.md']);
-  });
-
-  it('applies the same record to every client sharing that agentsPath', () => {
-    const workspacePath = '/workspace';
-    const copyResults: CopyResult[] = [
-      {
-        source: '/plugin/agents/cw-reviewer.md',
-        destination: '/workspace/.github/agents/cw-reviewer.md',
-        action: 'copied',
-      },
-    ];
-    const agentDedupeRecords: AgentDedupeRecord[] = [
-      {
-        name: 'cw-reviewer',
-        removedPath: '.github/agents/cw-reviewer.md',
-        keptPath: '.github/agents/cw-reviewer.agent.md',
-      },
-    ];
-    // After resolveClientMappings, vscode shares copilot's agentsPath — simulate
-    // that here directly so this test doesn't depend on that resolution step.
-    const mappings = {
-      ...CLIENT_MAPPINGS,
-      vscode: CLIENT_MAPPINGS.copilot,
-    };
-
-    const result = collectSyncedPaths(
-      copyResults,
-      workspacePath,
-      ['copilot', 'vscode'],
-      mappings,
-      agentDedupeRecords,
-    );
-
-    expect(result.copilot).toEqual(['.github/agents/cw-reviewer.agent.md']);
-    expect(result.vscode).toEqual(['.github/agents/cw-reviewer.agent.md']);
-  });
-
-  it('is a no-op for clients whose agentsPath does not match the record', () => {
-    const workspacePath = '/workspace';
-    const copyResults: CopyResult[] = [
-      {
-        source: '/plugin/agents/cw-reviewer.md',
-        destination: '/home/.claude/agents/cw-reviewer.md',
-        action: 'copied',
-      },
-    ];
-    const agentDedupeRecords: AgentDedupeRecord[] = [
-      {
-        name: 'cw-reviewer',
-        removedPath: '.github/agents/cw-reviewer.md',
-        keptPath: '.github/agents/cw-reviewer.agent.md',
-      },
-    ];
-
-    const result = collectSyncedPaths(
-      copyResults,
-      '/home',
-      ['claude'],
-      CLIENT_MAPPINGS,
-      agentDedupeRecords,
-    );
-
-    // claude's own copy of the richer .md agent is untouched by a dedup record
-    // that only concerns the .github/agents/ directory.
-    expect(result.claude).toEqual(['.claude/agents/cw-reviewer.md']);
-  });
-
-  it('does not duplicate the kept path if it was already tracked', () => {
-    const workspacePath = '/workspace';
+describe('collectSyncedPaths with planned agent outcomes', () => {
+  it('tracks the successful GitHub output and removes its successfully deduped portable twin', () => {
     const copyResults: CopyResult[] = [
       {
         source: '/plugin/agents/cw-reviewer.md',
@@ -112,22 +26,106 @@ describe('collectSyncedPaths with agentDedupeRecords', () => {
         action: 'copied',
       },
     ];
-    const agentDedupeRecords: AgentDedupeRecord[] = [
+
+    expect(
+      collectSyncedPaths(
+        copyResults,
+        '/workspace',
+        ['copilot'],
+        CLIENT_MAPPINGS,
+        [deduped],
+      ).copilot,
+    ).toEqual(['.github/agents/cw-reviewer.agent.md']);
+  });
+
+  it('does not invent ownership of a kept path that has no successful copy result', () => {
+    const copyResults: CopyResult[] = [
       {
-        name: 'cw-reviewer',
-        removedPath: '.github/agents/cw-reviewer.md',
-        keptPath: '.github/agents/cw-reviewer.agent.md',
+        source: '/plugin/agents/cw-reviewer.md',
+        destination: '/workspace/.github/agents/cw-reviewer.md',
+        action: 'copied',
+      },
+    ];
+
+    expect(
+      collectSyncedPaths(
+        copyResults,
+        '/workspace',
+        ['copilot'],
+        CLIENT_MAPPINGS,
+        [deduped],
+      ).copilot,
+    ).toEqual([]);
+  });
+
+  it('keeps tracking portable output when the preferred GitHub copy failed', () => {
+    const copyResults: CopyResult[] = [
+      {
+        source: '/plugin/agents/cw-reviewer.md',
+        destination: '/workspace/.github/agents/cw-reviewer.md',
+        action: 'copied',
+      },
+      {
+        source: '/plugin/.github/agents/cw-reviewer.agent.md',
+        destination: '/workspace/.github/agents/cw-reviewer.agent.md',
+        action: 'failed',
+        error: 'EISDIR',
+      },
+    ];
+
+    expect(
+      collectSyncedPaths(
+        copyResults,
+        '/workspace',
+        ['copilot'],
+        CLIENT_MAPPINGS,
+      ).copilot,
+    ).toEqual(['.github/agents/cw-reviewer.md']);
+  });
+
+  it('tracks a GitHub-format-only agent from its individual copy result', () => {
+    const copyResults: CopyResult[] = [
+      {
+        source: '/plugin/.github/agents/cw-reviewer.agent.md',
+        destination: '/workspace/.github/agents/cw-reviewer.agent.md',
+        action: 'copied',
+      },
+    ];
+
+    expect(
+      collectSyncedPaths(
+        copyResults,
+        '/workspace',
+        ['copilot'],
+        CLIENT_MAPPINGS,
+      ).copilot,
+    ).toEqual(['.github/agents/cw-reviewer.agent.md']);
+  });
+
+  it('projects a shared agents path for every consuming client', () => {
+    const mappings = {
+      ...CLIENT_MAPPINGS,
+      vscode: CLIENT_MAPPINGS.copilot,
+    };
+    const copyResults: CopyResult[] = [
+      {
+        source: '/plugin/.github/agents/cw-reviewer.agent.md',
+        destination: '/workspace/.github/agents/cw-reviewer.agent.md',
+        action: 'copied',
       },
     ];
 
     const result = collectSyncedPaths(
       copyResults,
-      workspacePath,
-      ['copilot'],
-      CLIENT_MAPPINGS,
-      agentDedupeRecords,
+      '/workspace',
+      ['copilot', 'vscode'],
+      mappings,
     );
-
-    expect(result.copilot).toEqual(['.github/agents/cw-reviewer.agent.md']);
+    expect(result.copilot).toEqual([
+      '.github/agents/cw-reviewer.agent.md',
+    ]);
+    expect(result.vscode).toEqual([
+      '.github/agents/cw-reviewer.agent.md',
+    ]);
   });
 });

--- a/tests/unit/core/agent-dedupe.test.ts
+++ b/tests/unit/core/agent-dedupe.test.ts
@@ -1,280 +1,320 @@
-import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
-import { mkdtemp, rm, mkdir, writeFile, readdir, readFile } from 'node:fs/promises';
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import { existsSync } from 'node:fs';
-import { join } from 'node:path';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
 import { tmpdir } from 'node:os';
 import {
+  copyPluginToWorkspace,
   dedupeAgentFilesByName,
-  type AgentDedupeSource,
+  planAgentOutputs,
+  type AgentOutputPlan,
 } from '../../../src/core/transform.js';
+import { CLIENT_MAPPINGS } from '../../../src/models/client-mapping.js';
 
-describe('dedupeAgentFilesByName', () => {
+const agent = (name: string, body: string) =>
+  `---\nname: ${name}\n---\n\n${body}\n`;
+
+describe('planned agent output dedupe', () => {
   let testDir: string;
   let pluginDir: string;
   let workspaceDir: string;
-  let agentsDir: string;
 
   beforeEach(async () => {
     testDir = await mkdtemp(join(tmpdir(), 'allagents-agent-dedupe-'));
     pluginDir = join(testDir, 'plugin');
     workspaceDir = join(testDir, 'workspace');
-    agentsDir = join(workspaceDir, '.github', 'agents');
     await mkdir(pluginDir, { recursive: true });
-    await mkdir(agentsDir, { recursive: true });
+    await mkdir(workspaceDir, { recursive: true });
   });
 
   afterEach(async () => {
     await rm(testDir, { recursive: true, force: true });
   });
 
-  /** Write a plugin's root agents/<name>.md source file. */
-  async function writePortableAgent(name: string, content: string) {
-    const dir = join(pluginDir, 'agents');
-    await mkdir(dir, { recursive: true });
-    await writeFile(join(dir, name), content);
+  async function writeAgent(
+    pluginPath: string,
+    sourcePath: string,
+    name: string,
+    body: string,
+  ): Promise<void> {
+    const path = join(pluginPath, sourcePath);
+    await mkdir(dirname(path), { recursive: true });
+    await writeFile(path, agent(name, body));
   }
 
-  /** Write a plugin's .github/agents/<name>.agent.md source file. */
-  async function writeGithubAgent(name: string, content: string) {
-    const dir = join(pluginDir, '.github', 'agents');
-    await mkdir(dir, { recursive: true });
-    await writeFile(join(dir, name), content);
-  }
-
-  /** Simulate copyAgents/copyGitHubContent having already run for these files. */
-  async function materializeDestination(names: string[]) {
-    for (const name of names) {
-      const source = existsSync(join(pluginDir, 'agents', name))
-        ? join(pluginDir, 'agents', name)
-        : join(pluginDir, '.github', 'agents', name);
-      await writeFile(join(agentsDir, name), await readFile(source, 'utf-8'));
-    }
-  }
-
-  it('removes the plain .md file when a .agent.md file declares the same name', async () => {
-    await writePortableAgent(
-      'cw-reviewer.md',
-      '---\nname: cw-reviewer\nargument-hint: PR number\n---\n\nportable version',
-    );
-    await writeGithubAgent(
-      'cw-reviewer.agent.md',
-      '---\nname: cw-reviewer\n---\n\ngithub-native version',
-    );
-    await materializeDestination(['cw-reviewer.md', 'cw-reviewer.agent.md']);
-
-    const sources: AgentDedupeSource[] = [{ pluginPath: pluginDir }];
-    const records = await dedupeAgentFilesByName(
-      workspaceDir,
-      '.github/agents/',
-      sources,
-    );
-
-    expect(records).toEqual([
-      {
-        name: 'cw-reviewer',
-        removedPath: '.github/agents/cw-reviewer.md',
-        keptPath: '.github/agents/cw-reviewer.agent.md',
-      },
-    ]);
-    expect(existsSync(join(agentsDir, 'cw-reviewer.md'))).toBe(false);
-    expect(existsSync(join(agentsDir, 'cw-reviewer.agent.md'))).toBe(true);
-  });
-
-  it('leaves files alone when only one variant exists', async () => {
-    await writePortableAgent('cw-coder.md', '---\nname: cw-coder\n---\n');
-    await writeGithubAgent(
-      'round-table-worker.agent.md',
-      '---\nname: round-table-worker\n---\n',
-    );
-    await materializeDestination(['cw-coder.md', 'round-table-worker.agent.md']);
-
-    const records = await dedupeAgentFilesByName(
-      workspaceDir,
-      '.github/agents/',
-      [{ pluginPath: pluginDir }],
-    );
-
-    expect(records).toEqual([]);
-    const remaining = await readdir(agentsDir);
-    expect(remaining.sort()).toEqual([
-      'cw-coder.md',
-      'round-table-worker.agent.md',
-    ]);
-  });
-
-  it('does not delete files whose frontmatter has no readable name field', async () => {
-    await writePortableAgent('broken.md', 'no frontmatter here');
-    await writeGithubAgent(
-      'broken.agent.md',
-      '---\ndescription: missing a name field\n---\n',
-    );
-    await materializeDestination(['broken.md', 'broken.agent.md']);
-
-    const records = await dedupeAgentFilesByName(
-      workspaceDir,
-      '.github/agents/',
-      [{ pluginPath: pluginDir }],
-    );
-
-    expect(records).toEqual([]);
-    expect(existsSync(join(agentsDir, 'broken.md'))).toBe(true);
-    expect(existsSync(join(agentsDir, 'broken.agent.md'))).toBe(true);
-  });
-
-  it('reports removals without deleting anything in dry-run mode', async () => {
-    await writePortableAgent('layout-agent.md', '---\nname: layout-agent\n---\n');
-    await writeGithubAgent(
-      'layout-agent.agent.md',
-      '---\nname: layout-agent\n---\n',
-    );
-    await materializeDestination(['layout-agent.md', 'layout-agent.agent.md']);
-
-    const records = await dedupeAgentFilesByName(
-      workspaceDir,
-      '.github/agents/',
-      [{ pluginPath: pluginDir }],
-      { dryRun: true },
-    );
-
-    expect(records).toEqual([
-      {
-        name: 'layout-agent',
-        removedPath: '.github/agents/layout-agent.md',
-        keptPath: '.github/agents/layout-agent.agent.md',
-      },
-    ]);
-    // Dry run must not touch disk.
-    expect(existsSync(join(agentsDir, 'layout-agent.md'))).toBe(true);
-    expect(existsSync(join(agentsDir, 'layout-agent.agent.md'))).toBe(true);
-  });
-
-  it('reports what a fresh sync would dedupe even before any destination file exists', async () => {
-    // Regression test: dry-run must reason from plugin *source* files, not
-    // the destination directory, so a brand-new workspace still gets an
-    // accurate preview instead of silently finding nothing.
-    await writePortableAgent(
-      'message-mapper.md',
-      '---\nname: message-mapper\n---\n',
-    );
-    await writeGithubAgent(
-      'message-mapper.agent.md',
-      '---\nname: message-mapper\n---\n',
-    );
-    // Deliberately not calling materializeDestination() — agentsDir is empty.
-
-    const records = await dedupeAgentFilesByName(
-      workspaceDir,
-      '.github/agents/',
-      [{ pluginPath: pluginDir }],
-      { dryRun: true },
-    );
-
-    expect(records).toEqual([
-      {
-        name: 'message-mapper',
-        removedPath: '.github/agents/message-mapper.md',
-        keptPath: '.github/agents/message-mapper.agent.md',
-      },
-    ]);
-  });
-
-  it('never touches a file the given plugins do not ship, even if it collides on disk', async () => {
-    // A user (or an unrelated, unconfigured plugin) created these directly in
-    // the destination directory. No plugin in `sources` ships either file.
-    await writeFile(
-      join(agentsDir, 'foo.md'),
-      '---\nname: foo\n---\n\nuser-owned',
-    );
-    await writeFile(
-      join(agentsDir, 'foo.agent.md'),
-      '---\nname: foo\n---\n\nuser-owned',
-    );
-
-    const records = await dedupeAgentFilesByName(
-      workspaceDir,
-      '.github/agents/',
-      [{ pluginPath: pluginDir }], // pluginDir has no agents/ or .github/agents/ at all
-    );
-
-    expect(records).toEqual([]);
-    expect(existsSync(join(agentsDir, 'foo.md'))).toBe(true);
-    expect(existsSync(join(agentsDir, 'foo.agent.md'))).toBe(true);
-  });
-
-  it('excludes candidates matching the plugin exclude patterns', async () => {
-    await writePortableAgent(
-      'excluded-agent.md',
-      '---\nname: excluded-agent\n---\n',
-    );
-    await writeGithubAgent(
-      'excluded-agent.agent.md',
-      '---\nname: excluded-agent\n---\n',
-    );
-    await materializeDestination(['excluded-agent.md', 'excluded-agent.agent.md']);
-
-    const records = await dedupeAgentFilesByName(
-      workspaceDir,
-      '.github/agents/',
-      [{ pluginPath: pluginDir, exclude: ['agents/**'] }],
-    );
-
-    // The root agents/*.md candidate is excluded, so there is no plain .md
-    // candidate left to collapse — the .github/agents/*.agent.md one is
-    // untouched either way.
-    expect(records).toEqual([]);
-    expect(existsSync(join(agentsDir, 'excluded-agent.md'))).toBe(true);
-  });
-
-  it('skips a source entirely when fileArtifacts marks it as not provided', async () => {
-    await writePortableAgent('gated.md', '---\nname: gated\n---\n');
-    await writeGithubAgent('gated.agent.md', '---\nname: gated\n---\n');
-    await materializeDestination(['gated.md', 'gated.agent.md']);
-
-    const records = await dedupeAgentFilesByName(
-      workspaceDir,
-      '.github/agents/',
+  async function plan(pluginPath = pluginDir): Promise<AgentOutputPlan> {
+    return planAgentOutputs(
       [
         {
+          configurationIndex: 0,
+          plugin: pluginPath,
+          pluginPath,
+          clients: ['copilot'],
+        },
+      ],
+      workspaceDir,
+      CLIENT_MAPPINGS,
+    );
+  }
+
+  it('removes a portable representation only after both exact planned copies succeed', async () => {
+    await writeAgent(
+      pluginDir,
+      'agents/reviewer.md',
+      'reviewer',
+      'Portable',
+    );
+    await writeAgent(
+      pluginDir,
+      '.github/agents/reviewer.agent.md',
+      'reviewer',
+      'GitHub',
+    );
+    const outputPlan = await plan();
+
+    const results = await copyPluginToWorkspace(
+      pluginDir,
+      workspaceDir,
+      'copilot',
+      { agentOutputs: outputPlan.outputs },
+    );
+    const records = await dedupeAgentFilesByName(outputPlan, results);
+
+    expect(records).toEqual([
+      {
+        name: 'reviewer',
+        removedPath: '.github/agents/reviewer.md',
+        keptPath: '.github/agents/reviewer.agent.md',
+      },
+    ]);
+    expect(existsSync(join(workspaceDir, '.github/agents/reviewer.md'))).toBe(
+      false,
+    );
+    expect(
+      await readFile(
+        join(workspaceDir, '.github/agents/reviewer.agent.md'),
+        'utf-8',
+      ),
+    ).toContain('GitHub');
+  });
+
+  it('preserves the portable representation when the preferred copy fails', async () => {
+    await writeAgent(
+      pluginDir,
+      'agents/reviewer.md',
+      'reviewer',
+      'Portable',
+    );
+    await writeAgent(
+      pluginDir,
+      '.github/agents/reviewer.agent.md',
+      'reviewer',
+      'GitHub',
+    );
+    await mkdir(join(workspaceDir, '.github/agents/reviewer.agent.md'), {
+      recursive: true,
+    });
+    const outputPlan = await plan();
+
+    const results = await copyPluginToWorkspace(
+      pluginDir,
+      workspaceDir,
+      'copilot',
+      { agentOutputs: outputPlan.outputs },
+    );
+    const records = await dedupeAgentFilesByName(outputPlan, results);
+
+    expect(
+      results.some(
+        (result) =>
+          result.destination.endsWith('reviewer.agent.md') &&
+          result.action === 'failed',
+      ),
+    ).toBe(true);
+    expect(records).toEqual([]);
+    expect(existsSync(join(workspaceDir, '.github/agents/reviewer.md'))).toBe(
+      true,
+    );
+  });
+
+  it('does not claim removal when unlinking the portable representation fails', async () => {
+    await writeAgent(
+      pluginDir,
+      'agents/reviewer.md',
+      'reviewer',
+      'Portable',
+    );
+    await writeAgent(
+      pluginDir,
+      '.github/agents/reviewer.agent.md',
+      'reviewer',
+      'GitHub',
+    );
+    const outputPlan = await plan();
+    const results = await copyPluginToWorkspace(
+      pluginDir,
+      workspaceDir,
+      'copilot',
+      { agentOutputs: outputPlan.outputs },
+    );
+    const portablePath = join(workspaceDir, '.github/agents/reviewer.md');
+    await rm(portablePath);
+    await mkdir(portablePath);
+    const warnings: string[] = [];
+
+    const records = await dedupeAgentFilesByName(outputPlan, results, {
+      onWarning: (warning) => warnings.push(warning),
+    });
+
+    expect(records).toEqual([]);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('failed to remove');
+    expect(existsSync(portablePath)).toBe(true);
+  });
+
+  it('gives an earlier configured plugin destination ownership without hiding a later distinct GitHub agent', async () => {
+    const pluginA = join(testDir, 'plugin-a');
+    const pluginB = join(testDir, 'plugin-b');
+    await writeAgent(pluginA, 'agents/shared.md', 'alpha', 'A');
+    await writeAgent(pluginB, 'agents/shared.md', 'beta', 'B portable');
+    await writeAgent(
+      pluginB,
+      '.github/agents/beta.agent.md',
+      'beta',
+      'B GitHub',
+    );
+
+    const outputPlan = await planAgentOutputs(
+      [
+        {
+          configurationIndex: 0,
+          plugin: 'plugin-a',
+          pluginPath: pluginA,
+          clients: ['copilot'],
+        },
+        {
+          configurationIndex: 1,
+          plugin: 'plugin-b',
+          pluginPath: pluginB,
+          clients: ['copilot'],
+        },
+      ],
+      workspaceDir,
+      CLIENT_MAPPINGS,
+    );
+
+    expect(
+      outputPlan.outputs.map((output) => [
+        output.plugin,
+        output.workspaceRelativeDestination,
+      ]),
+    ).toEqual([
+      ['plugin-a', '.github/agents/shared.md'],
+      ['plugin-b', '.github/agents/beta.agent.md'],
+    ]);
+    expect(outputPlan.conflicts).toHaveLength(1);
+    expect(outputPlan.conflicts[0]?.winner.plugin).toBe('plugin-a');
+    expect(outputPlan.conflicts[0]?.loser.plugin).toBe('plugin-b');
+  });
+
+  it('uses logical names to prevent a later plugin from owning a second destination', async () => {
+    const pluginA = join(testDir, 'plugin-a');
+    const pluginB = join(testDir, 'plugin-b');
+    await writeAgent(pluginA, 'agents/first.md', 'shared-agent', 'A');
+    await writeAgent(
+      pluginB,
+      '.github/agents/second.agent.md',
+      'shared-agent',
+      'B',
+    );
+
+    const outputPlan = await planAgentOutputs(
+      [
+        {
+          configurationIndex: 0,
+          plugin: 'plugin-a',
+          pluginPath: pluginA,
+          clients: ['copilot'],
+        },
+        {
+          configurationIndex: 1,
+          plugin: 'plugin-b',
+          pluginPath: pluginB,
+          clients: ['copilot'],
+        },
+      ],
+      workspaceDir,
+      CLIENT_MAPPINGS,
+    );
+
+    expect(outputPlan.outputs).toHaveLength(1);
+    expect(outputPlan.outputs[0]?.plugin).toBe('plugin-a');
+    expect(outputPlan.conflicts[0]?.reason).toBe('logical-name');
+  });
+
+  it('applies excludes and marketplace artifact gates while planning', async () => {
+    await writeAgent(pluginDir, 'agents/keep.md', 'keep', 'Keep');
+    await writeAgent(pluginDir, 'agents/drop.md', 'drop', 'Drop');
+    await writeAgent(
+      pluginDir,
+      '.github/agents/github.agent.md',
+      'github',
+      'GitHub',
+    );
+
+    const outputPlan = await planAgentOutputs(
+      [
+        {
+          configurationIndex: 0,
+          plugin: 'plugin',
           pluginPath: pluginDir,
+          clients: ['copilot'],
+          exclude: ['agents/drop.md'],
           fileArtifacts: {
+            agents: true,
             commands: true,
-            skills: true,
+            github: false,
             hooks: true,
-            agents: false, // this marketplace entry does not declare agents
             mcpServers: true,
-            github: true,
+            skills: true,
           },
         },
       ],
+      workspaceDir,
+      CLIENT_MAPPINGS,
     );
 
-    expect(records).toEqual([]);
-    expect(existsSync(join(agentsDir, 'gated.md'))).toBe(true);
+    expect(
+      outputPlan.outputs.map((output) => output.workspaceRelativeDestination),
+    ).toEqual(['.github/agents/keep.md']);
   });
 
-  it('matches by frontmatter name, not by filename stem', async () => {
-    // Filenames deliberately do not share a stem — only the `name:` field matches.
-    await writePortableAgent(
-      'legacy-filename.md',
-      '---\nname: cus-gen-dbd-agent\n---\n',
+  it('uses the same ownership and dedupe decisions in dry-run without writing', async () => {
+    await writeAgent(
+      pluginDir,
+      'agents/reviewer.md',
+      'reviewer',
+      'Portable',
     );
-    await writeGithubAgent(
-      'cus-gen-dbd-agent.agent.md',
-      '---\nname: cus-gen-dbd-agent\n---\n',
+    await writeAgent(
+      pluginDir,
+      '.github/agents/reviewer.agent.md',
+      'reviewer',
+      'GitHub',
     );
-    await materializeDestination([
-      'legacy-filename.md',
-      'cus-gen-dbd-agent.agent.md',
-    ]);
+    const outputPlan = await plan();
 
-    const records = await dedupeAgentFilesByName(
+    const results = await copyPluginToWorkspace(
+      pluginDir,
       workspaceDir,
-      '.github/agents/',
-      [{ pluginPath: pluginDir }],
+      'copilot',
+      { dryRun: true, agentOutputs: outputPlan.outputs },
     );
+    const records = await dedupeAgentFilesByName(outputPlan, results, {
+      dryRun: true,
+    });
 
     expect(records).toHaveLength(1);
-    expect(records[0]?.removedPath).toBe('.github/agents/legacy-filename.md');
-    expect(existsSync(join(agentsDir, 'legacy-filename.md'))).toBe(false);
+    expect(existsSync(join(workspaceDir, '.github'))).toBe(false);
   });
 });

--- a/tests/unit/core/agent-dedupe.test.ts
+++ b/tests/unit/core/agent-dedupe.test.ts
@@ -1,17 +1,25 @@
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
-import { mkdtemp, rm, mkdir, writeFile, readdir } from 'node:fs/promises';
+import { mkdtemp, rm, mkdir, writeFile, readdir, readFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { dedupeAgentFilesByName } from '../../../src/core/transform.js';
+import {
+  dedupeAgentFilesByName,
+  type AgentDedupeSource,
+} from '../../../src/core/transform.js';
 
 describe('dedupeAgentFilesByName', () => {
   let testDir: string;
+  let pluginDir: string;
+  let workspaceDir: string;
   let agentsDir: string;
 
   beforeEach(async () => {
     testDir = await mkdtemp(join(tmpdir(), 'allagents-agent-dedupe-'));
-    agentsDir = join(testDir, '.github', 'agents');
+    pluginDir = join(testDir, 'plugin');
+    workspaceDir = join(testDir, 'workspace');
+    agentsDir = join(workspaceDir, '.github', 'agents');
+    await mkdir(pluginDir, { recursive: true });
     await mkdir(agentsDir, { recursive: true });
   });
 
@@ -19,17 +27,47 @@ describe('dedupeAgentFilesByName', () => {
     await rm(testDir, { recursive: true, force: true });
   });
 
+  /** Write a plugin's root agents/<name>.md source file. */
+  async function writePortableAgent(name: string, content: string) {
+    const dir = join(pluginDir, 'agents');
+    await mkdir(dir, { recursive: true });
+    await writeFile(join(dir, name), content);
+  }
+
+  /** Write a plugin's .github/agents/<name>.agent.md source file. */
+  async function writeGithubAgent(name: string, content: string) {
+    const dir = join(pluginDir, '.github', 'agents');
+    await mkdir(dir, { recursive: true });
+    await writeFile(join(dir, name), content);
+  }
+
+  /** Simulate copyAgents/copyGitHubContent having already run for these files. */
+  async function materializeDestination(names: string[]) {
+    for (const name of names) {
+      const source = existsSync(join(pluginDir, 'agents', name))
+        ? join(pluginDir, 'agents', name)
+        : join(pluginDir, '.github', 'agents', name);
+      await writeFile(join(agentsDir, name), await readFile(source, 'utf-8'));
+    }
+  }
+
   it('removes the plain .md file when a .agent.md file declares the same name', async () => {
-    await writeFile(
-      join(agentsDir, 'cw-reviewer.md'),
+    await writePortableAgent(
+      'cw-reviewer.md',
       '---\nname: cw-reviewer\nargument-hint: PR number\n---\n\nportable version',
     );
-    await writeFile(
-      join(agentsDir, 'cw-reviewer.agent.md'),
+    await writeGithubAgent(
+      'cw-reviewer.agent.md',
       '---\nname: cw-reviewer\n---\n\ngithub-native version',
     );
+    await materializeDestination(['cw-reviewer.md', 'cw-reviewer.agent.md']);
 
-    const records = await dedupeAgentFilesByName(testDir, '.github/agents/');
+    const sources: AgentDedupeSource[] = [{ pluginPath: pluginDir }];
+    const records = await dedupeAgentFilesByName(
+      workspaceDir,
+      '.github/agents/',
+      sources,
+    );
 
     expect(records).toEqual([
       {
@@ -43,16 +81,18 @@ describe('dedupeAgentFilesByName', () => {
   });
 
   it('leaves files alone when only one variant exists', async () => {
-    await writeFile(
-      join(agentsDir, 'cw-coder.md'),
-      '---\nname: cw-coder\n---\n\nno agent.md sibling',
+    await writePortableAgent('cw-coder.md', '---\nname: cw-coder\n---\n');
+    await writeGithubAgent(
+      'round-table-worker.agent.md',
+      '---\nname: round-table-worker\n---\n',
     );
-    await writeFile(
-      join(agentsDir, 'round-table-worker.agent.md'),
-      '---\nname: round-table-worker\n---\n\nno plain .md sibling',
-    );
+    await materializeDestination(['cw-coder.md', 'round-table-worker.agent.md']);
 
-    const records = await dedupeAgentFilesByName(testDir, '.github/agents/');
+    const records = await dedupeAgentFilesByName(
+      workspaceDir,
+      '.github/agents/',
+      [{ pluginPath: pluginDir }],
+    );
 
     expect(records).toEqual([]);
     const remaining = await readdir(agentsDir);
@@ -63,13 +103,18 @@ describe('dedupeAgentFilesByName', () => {
   });
 
   it('does not delete files whose frontmatter has no readable name field', async () => {
-    await writeFile(join(agentsDir, 'broken.md'), 'no frontmatter here');
-    await writeFile(
-      join(agentsDir, 'broken.agent.md'),
+    await writePortableAgent('broken.md', 'no frontmatter here');
+    await writeGithubAgent(
+      'broken.agent.md',
       '---\ndescription: missing a name field\n---\n',
     );
+    await materializeDestination(['broken.md', 'broken.agent.md']);
 
-    const records = await dedupeAgentFilesByName(testDir, '.github/agents/');
+    const records = await dedupeAgentFilesByName(
+      workspaceDir,
+      '.github/agents/',
+      [{ pluginPath: pluginDir }],
+    );
 
     expect(records).toEqual([]);
     expect(existsSync(join(agentsDir, 'broken.md'))).toBe(true);
@@ -77,18 +122,19 @@ describe('dedupeAgentFilesByName', () => {
   });
 
   it('reports removals without deleting anything in dry-run mode', async () => {
-    await writeFile(
-      join(agentsDir, 'layout-agent.md'),
+    await writePortableAgent('layout-agent.md', '---\nname: layout-agent\n---\n');
+    await writeGithubAgent(
+      'layout-agent.agent.md',
       '---\nname: layout-agent\n---\n',
     );
-    await writeFile(
-      join(agentsDir, 'layout-agent.agent.md'),
-      '---\nname: layout-agent\n---\n',
-    );
+    await materializeDestination(['layout-agent.md', 'layout-agent.agent.md']);
 
-    const records = await dedupeAgentFilesByName(testDir, '.github/agents/', {
-      dryRun: true,
-    });
+    const records = await dedupeAgentFilesByName(
+      workspaceDir,
+      '.github/agents/',
+      [{ pluginPath: pluginDir }],
+      { dryRun: true },
+    );
 
     expect(records).toEqual([
       {
@@ -102,23 +148,130 @@ describe('dedupeAgentFilesByName', () => {
     expect(existsSync(join(agentsDir, 'layout-agent.agent.md'))).toBe(true);
   });
 
-  it('returns empty when the agents directory does not exist', async () => {
-    const records = await dedupeAgentFilesByName(testDir, '.claude/agents/');
+  it('reports what a fresh sync would dedupe even before any destination file exists', async () => {
+    // Regression test: dry-run must reason from plugin *source* files, not
+    // the destination directory, so a brand-new workspace still gets an
+    // accurate preview instead of silently finding nothing.
+    await writePortableAgent(
+      'message-mapper.md',
+      '---\nname: message-mapper\n---\n',
+    );
+    await writeGithubAgent(
+      'message-mapper.agent.md',
+      '---\nname: message-mapper\n---\n',
+    );
+    // Deliberately not calling materializeDestination() — agentsDir is empty.
+
+    const records = await dedupeAgentFilesByName(
+      workspaceDir,
+      '.github/agents/',
+      [{ pluginPath: pluginDir }],
+      { dryRun: true },
+    );
+
+    expect(records).toEqual([
+      {
+        name: 'message-mapper',
+        removedPath: '.github/agents/message-mapper.md',
+        keptPath: '.github/agents/message-mapper.agent.md',
+      },
+    ]);
+  });
+
+  it('never touches a file the given plugins do not ship, even if it collides on disk', async () => {
+    // A user (or an unrelated, unconfigured plugin) created these directly in
+    // the destination directory. No plugin in `sources` ships either file.
+    await writeFile(
+      join(agentsDir, 'foo.md'),
+      '---\nname: foo\n---\n\nuser-owned',
+    );
+    await writeFile(
+      join(agentsDir, 'foo.agent.md'),
+      '---\nname: foo\n---\n\nuser-owned',
+    );
+
+    const records = await dedupeAgentFilesByName(
+      workspaceDir,
+      '.github/agents/',
+      [{ pluginPath: pluginDir }], // pluginDir has no agents/ or .github/agents/ at all
+    );
+
     expect(records).toEqual([]);
+    expect(existsSync(join(agentsDir, 'foo.md'))).toBe(true);
+    expect(existsSync(join(agentsDir, 'foo.agent.md'))).toBe(true);
+  });
+
+  it('excludes candidates matching the plugin exclude patterns', async () => {
+    await writePortableAgent(
+      'excluded-agent.md',
+      '---\nname: excluded-agent\n---\n',
+    );
+    await writeGithubAgent(
+      'excluded-agent.agent.md',
+      '---\nname: excluded-agent\n---\n',
+    );
+    await materializeDestination(['excluded-agent.md', 'excluded-agent.agent.md']);
+
+    const records = await dedupeAgentFilesByName(
+      workspaceDir,
+      '.github/agents/',
+      [{ pluginPath: pluginDir, exclude: ['agents/**'] }],
+    );
+
+    // The root agents/*.md candidate is excluded, so there is no plain .md
+    // candidate left to collapse — the .github/agents/*.agent.md one is
+    // untouched either way.
+    expect(records).toEqual([]);
+    expect(existsSync(join(agentsDir, 'excluded-agent.md'))).toBe(true);
+  });
+
+  it('skips a source entirely when fileArtifacts marks it as not provided', async () => {
+    await writePortableAgent('gated.md', '---\nname: gated\n---\n');
+    await writeGithubAgent('gated.agent.md', '---\nname: gated\n---\n');
+    await materializeDestination(['gated.md', 'gated.agent.md']);
+
+    const records = await dedupeAgentFilesByName(
+      workspaceDir,
+      '.github/agents/',
+      [
+        {
+          pluginPath: pluginDir,
+          fileArtifacts: {
+            commands: true,
+            skills: true,
+            hooks: true,
+            agents: false, // this marketplace entry does not declare agents
+            mcpServers: true,
+            github: true,
+          },
+        },
+      ],
+    );
+
+    expect(records).toEqual([]);
+    expect(existsSync(join(agentsDir, 'gated.md'))).toBe(true);
   });
 
   it('matches by frontmatter name, not by filename stem', async () => {
     // Filenames deliberately do not share a stem — only the `name:` field matches.
-    await writeFile(
-      join(agentsDir, 'legacy-filename.md'),
+    await writePortableAgent(
+      'legacy-filename.md',
       '---\nname: cus-gen-dbd-agent\n---\n',
     );
-    await writeFile(
-      join(agentsDir, 'cus-gen-dbd-agent.agent.md'),
+    await writeGithubAgent(
+      'cus-gen-dbd-agent.agent.md',
       '---\nname: cus-gen-dbd-agent\n---\n',
     );
+    await materializeDestination([
+      'legacy-filename.md',
+      'cus-gen-dbd-agent.agent.md',
+    ]);
 
-    const records = await dedupeAgentFilesByName(testDir, '.github/agents/');
+    const records = await dedupeAgentFilesByName(
+      workspaceDir,
+      '.github/agents/',
+      [{ pluginPath: pluginDir }],
+    );
 
     expect(records).toHaveLength(1);
     expect(records[0]?.removedPath).toBe('.github/agents/legacy-filename.md');

--- a/tests/unit/core/agent-dedupe.test.ts
+++ b/tests/unit/core/agent-dedupe.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtemp, rm, mkdir, writeFile, readdir } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { dedupeAgentFilesByName } from '../../../src/core/transform.js';
+
+describe('dedupeAgentFilesByName', () => {
+  let testDir: string;
+  let agentsDir: string;
+
+  beforeEach(async () => {
+    testDir = await mkdtemp(join(tmpdir(), 'allagents-agent-dedupe-'));
+    agentsDir = join(testDir, '.github', 'agents');
+    await mkdir(agentsDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  it('removes the plain .md file when a .agent.md file declares the same name', async () => {
+    await writeFile(
+      join(agentsDir, 'cw-reviewer.md'),
+      '---\nname: cw-reviewer\nargument-hint: PR number\n---\n\nportable version',
+    );
+    await writeFile(
+      join(agentsDir, 'cw-reviewer.agent.md'),
+      '---\nname: cw-reviewer\n---\n\ngithub-native version',
+    );
+
+    const records = await dedupeAgentFilesByName(testDir, '.github/agents/');
+
+    expect(records).toEqual([
+      {
+        name: 'cw-reviewer',
+        removedPath: '.github/agents/cw-reviewer.md',
+        keptPath: '.github/agents/cw-reviewer.agent.md',
+      },
+    ]);
+    expect(existsSync(join(agentsDir, 'cw-reviewer.md'))).toBe(false);
+    expect(existsSync(join(agentsDir, 'cw-reviewer.agent.md'))).toBe(true);
+  });
+
+  it('leaves files alone when only one variant exists', async () => {
+    await writeFile(
+      join(agentsDir, 'cw-coder.md'),
+      '---\nname: cw-coder\n---\n\nno agent.md sibling',
+    );
+    await writeFile(
+      join(agentsDir, 'round-table-worker.agent.md'),
+      '---\nname: round-table-worker\n---\n\nno plain .md sibling',
+    );
+
+    const records = await dedupeAgentFilesByName(testDir, '.github/agents/');
+
+    expect(records).toEqual([]);
+    const remaining = await readdir(agentsDir);
+    expect(remaining.sort()).toEqual([
+      'cw-coder.md',
+      'round-table-worker.agent.md',
+    ]);
+  });
+
+  it('does not delete files whose frontmatter has no readable name field', async () => {
+    await writeFile(join(agentsDir, 'broken.md'), 'no frontmatter here');
+    await writeFile(
+      join(agentsDir, 'broken.agent.md'),
+      '---\ndescription: missing a name field\n---\n',
+    );
+
+    const records = await dedupeAgentFilesByName(testDir, '.github/agents/');
+
+    expect(records).toEqual([]);
+    expect(existsSync(join(agentsDir, 'broken.md'))).toBe(true);
+    expect(existsSync(join(agentsDir, 'broken.agent.md'))).toBe(true);
+  });
+
+  it('reports removals without deleting anything in dry-run mode', async () => {
+    await writeFile(
+      join(agentsDir, 'layout-agent.md'),
+      '---\nname: layout-agent\n---\n',
+    );
+    await writeFile(
+      join(agentsDir, 'layout-agent.agent.md'),
+      '---\nname: layout-agent\n---\n',
+    );
+
+    const records = await dedupeAgentFilesByName(testDir, '.github/agents/', {
+      dryRun: true,
+    });
+
+    expect(records).toEqual([
+      {
+        name: 'layout-agent',
+        removedPath: '.github/agents/layout-agent.md',
+        keptPath: '.github/agents/layout-agent.agent.md',
+      },
+    ]);
+    // Dry run must not touch disk.
+    expect(existsSync(join(agentsDir, 'layout-agent.md'))).toBe(true);
+    expect(existsSync(join(agentsDir, 'layout-agent.agent.md'))).toBe(true);
+  });
+
+  it('returns empty when the agents directory does not exist', async () => {
+    const records = await dedupeAgentFilesByName(testDir, '.claude/agents/');
+    expect(records).toEqual([]);
+  });
+
+  it('matches by frontmatter name, not by filename stem', async () => {
+    // Filenames deliberately do not share a stem — only the `name:` field matches.
+    await writeFile(
+      join(agentsDir, 'legacy-filename.md'),
+      '---\nname: cus-gen-dbd-agent\n---\n',
+    );
+    await writeFile(
+      join(agentsDir, 'cus-gen-dbd-agent.agent.md'),
+      '---\nname: cus-gen-dbd-agent\n---\n',
+    );
+
+    const records = await dedupeAgentFilesByName(testDir, '.github/agents/');
+
+    expect(records).toHaveLength(1);
+    expect(records[0]?.removedPath).toBe('.github/agents/legacy-filename.md');
+    expect(existsSync(join(agentsDir, 'legacy-filename.md'))).toBe(false);
+  });
+});

--- a/tests/unit/core/github-content.test.ts
+++ b/tests/unit/core/github-content.test.ts
@@ -42,15 +42,60 @@ describe('copyGitHubContent', () => {
   it('copies .github/agents/ for copilot client', async () => {
     await mkdir(join(pluginDir, '.github', 'agents'), { recursive: true });
     await writeFile(join(pluginDir, '.github', 'agents', 'reviewer.agent.md'), '# Reviewer');
+    await mkdir(join(pluginDir, '.github', 'agents', 'support'), {
+      recursive: true,
+    });
+    await writeFile(
+      join(pluginDir, '.github', 'agents', 'support', 'schema.json'),
+      '{"type":"object"}',
+    );
 
     const results = await copyGitHubContent(pluginDir, workspaceDir, 'copilot');
 
-    expect(results).toHaveLength(1);
-    expect(results[0].action).toBe('copied');
+    expect(results).toHaveLength(2);
+    expect(results.every((result) => result.action === 'copied')).toBe(true);
     expect(existsSync(join(workspaceDir, '.github', 'agents', 'reviewer.agent.md'))).toBe(true);
+    expect(
+      existsSync(
+        join(
+          workspaceDir,
+          '.github',
+          'agents',
+          'support',
+          'schema.json',
+        ),
+      ),
+    ).toBe(true);
 
     const content = await readFile(join(workspaceDir, '.github', 'agents', 'reviewer.agent.md'), 'utf-8');
     expect(content).toBe('# Reviewer');
+  });
+
+  it('does not let dot-prefixed agent definitions bypass an ownership plan', async () => {
+    await mkdir(join(pluginDir, '.github', 'agents'), { recursive: true });
+    await writeFile(
+      join(pluginDir, '.github', 'agents', '.reviewer.agent.md'),
+      '# Reviewer',
+    );
+
+    const results = await copyGitHubContent(
+      pluginDir,
+      workspaceDir,
+      'copilot',
+      { agentOutputs: [] },
+    );
+
+    expect(results).toEqual([]);
+    expect(
+      existsSync(
+        join(
+          workspaceDir,
+          '.github',
+          'agents',
+          '.reviewer.agent.md',
+        ),
+      ),
+    ).toBe(false);
   });
 
   it('copies .github/hooks/ for copilot client', async () => {

--- a/tests/unit/core/sync-agent-dedupe.test.ts
+++ b/tests/unit/core/sync-agent-dedupe.test.ts
@@ -1,0 +1,437 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { existsSync } from 'node:fs';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { CONFIG_DIR, WORKSPACE_CONFIG_FILE } from '../../../src/constants.js';
+import { syncWorkspace } from '../../../src/core/sync.js';
+import type { SyncState } from '../../../src/models/sync-state.js';
+
+const agent = (name: string, body: string) =>
+  `---\nname: ${name}\ndescription: ${name}\n---\n\n${body}\n`;
+
+describe('syncWorkspace agent deduplication', () => {
+  let workspacePath: string;
+
+  beforeEach(async () => {
+    workspacePath = await mkdtemp(join(tmpdir(), 'allagents-agent-sync-'));
+  });
+
+  afterEach(async () => {
+    await rm(workspacePath, { recursive: true, force: true });
+  });
+
+  async function writePluginAgent(
+    pluginPath: string,
+    sourcePath: string,
+    name: string,
+    body: string,
+  ): Promise<void> {
+    const path = join(pluginPath, sourcePath);
+    await mkdir(dirname(path), { recursive: true });
+    await writeFile(path, agent(name, body));
+  }
+
+  async function writeWorkspace(
+    plugins: string[],
+    clients: string[] = ['copilot'],
+  ): Promise<void> {
+    await mkdir(join(workspacePath, CONFIG_DIR), { recursive: true });
+    await writeFile(
+      join(workspacePath, CONFIG_DIR, WORKSPACE_CONFIG_FILE),
+      [
+        'version: 2',
+        'repositories: []',
+        ...(plugins.length === 0
+          ? ['plugins: []']
+          : ['plugins:', ...plugins.map((plugin) => `  - ${plugin}`)]),
+        'clients:',
+        ...clients.map((client) => `  - ${client}`),
+        '',
+      ].join('\n'),
+    );
+  }
+
+  async function readState(): Promise<SyncState> {
+    return JSON.parse(
+      await readFile(join(workspacePath, CONFIG_DIR, 'sync-state.json'), 'utf-8'),
+    ) as SyncState;
+  }
+
+  it('dedupes Copilot without removing the Claude agent', async () => {
+    const pluginPath = join(workspacePath, 'plugin');
+    await writePluginAgent(
+      pluginPath,
+      'agents/reviewer.md',
+      'reviewer',
+      'Portable reviewer',
+    );
+    await writePluginAgent(
+      pluginPath,
+      '.github/agents/reviewer.agent.md',
+      'reviewer',
+      'GitHub reviewer',
+    );
+    await writeWorkspace([pluginPath], ['claude', 'copilot']);
+
+    const result = await syncWorkspace(workspacePath);
+
+    expect(result.success).toBe(true);
+    expect(result.totalCopied).toBe(2);
+    expect(existsSync(join(workspacePath, '.claude/agents/reviewer.md'))).toBe(
+      true,
+    );
+    expect(
+      existsSync(join(workspacePath, '.claude/agents/reviewer.agent.md')),
+    ).toBe(false);
+    expect(existsSync(join(workspacePath, '.github/agents/reviewer.md'))).toBe(
+      false,
+    );
+    expect(
+      existsSync(join(workspacePath, '.github/agents/reviewer.agent.md')),
+    ).toBe(true);
+
+    const state = await readState();
+    expect(state.files.claude).toEqual(['.claude/agents/reviewer.md']);
+    expect(state.files.copilot).toEqual([
+      '.github/agents/reviewer.agent.md',
+    ]);
+    expect(result.messages).toEqual([
+      "Deduped agent 'reviewer': removed .github/agents/reviewer.md (kept .github/agents/reviewer.agent.md)",
+    ]);
+  });
+
+  it('requires a GitHub-format .agent.md file before deduping', async () => {
+    const pluginPath = join(workspacePath, 'plugin');
+    await writePluginAgent(
+      pluginPath,
+      'agents/portable.md',
+      'reviewer',
+      'Portable reviewer',
+    );
+    await writePluginAgent(
+      pluginPath,
+      '.github/agents/github.md',
+      'reviewer',
+      'Plain GitHub markdown',
+    );
+    await writeWorkspace([pluginPath]);
+
+    const result = await syncWorkspace(workspacePath);
+
+    expect(result.success).toBe(true);
+    expect(existsSync(join(workspacePath, '.github/agents/portable.md'))).toBe(
+      true,
+    );
+    expect(existsSync(join(workspacePath, '.github/agents/github.md'))).toBe(
+      true,
+    );
+    expect(result.messages).toBeUndefined();
+  });
+
+  it('reports a fresh dry-run dedupe without writing files or state', async () => {
+    const pluginPath = join(workspacePath, 'plugin');
+    await writePluginAgent(
+      pluginPath,
+      'agents/reviewer.md',
+      'reviewer',
+      'Portable reviewer',
+    );
+    await writePluginAgent(
+      pluginPath,
+      '.github/agents/reviewer.agent.md',
+      'reviewer',
+      'GitHub reviewer',
+    );
+    await writeWorkspace([pluginPath]);
+
+    const result = await syncWorkspace(workspacePath, { dryRun: true });
+
+    expect(result.success).toBe(true);
+    expect(result.totalCopied).toBe(1);
+    expect(result.messages).toEqual([
+      "Would dedupe agent 'reviewer': removed .github/agents/reviewer.md (kept .github/agents/reviewer.agent.md)",
+    ]);
+    expect(existsSync(join(workspacePath, '.github'))).toBe(false);
+    expect(
+      existsSync(join(workspacePath, CONFIG_DIR, 'sync-state.json')),
+    ).toBe(false);
+  });
+
+  it('keeps the portable agent when the GitHub-format copy fails', async () => {
+    const pluginPath = join(workspacePath, 'plugin');
+    await writePluginAgent(
+      pluginPath,
+      'agents/reviewer.md',
+      'reviewer',
+      'Portable reviewer',
+    );
+    await writePluginAgent(
+      pluginPath,
+      '.github/agents/reviewer.agent.md',
+      'reviewer',
+      'GitHub reviewer',
+    );
+    await writePluginAgent(
+      pluginPath,
+      '.github/agents/healthy.agent.md',
+      'healthy',
+      'Healthy GitHub agent',
+    );
+    await writeWorkspace([pluginPath]);
+    await mkdir(join(workspacePath, '.github/agents/reviewer.agent.md'), {
+      recursive: true,
+    });
+
+    const result = await syncWorkspace(workspacePath);
+
+    expect(result.success).toBe(false);
+    expect(existsSync(join(workspacePath, '.github/agents/reviewer.md'))).toBe(
+      true,
+    );
+    expect(
+      existsSync(join(workspacePath, '.github/agents/healthy.agent.md')),
+    ).toBe(true);
+    expect(result.messages).toBeUndefined();
+    const state = await readState();
+    expect(state.files.copilot).toContain('.github/agents/reviewer.md');
+    expect(state.files.copilot).toContain('.github/agents/healthy.agent.md');
+    expect(state.files.copilot).not.toContain(
+      '.github/agents/reviewer.agent.md',
+    );
+  });
+
+  it('keeps tracking a GitHub-format agent after the portable source is removed', async () => {
+    const pluginPath = join(workspacePath, 'plugin');
+    const portableSource = join(pluginPath, 'agents/reviewer.md');
+    await writePluginAgent(
+      pluginPath,
+      'agents/reviewer.md',
+      'reviewer',
+      'Portable reviewer',
+    );
+    await writePluginAgent(
+      pluginPath,
+      '.github/agents/reviewer.agent.md',
+      'reviewer',
+      'GitHub reviewer',
+    );
+    await writeWorkspace([pluginPath]);
+
+    await syncWorkspace(workspacePath);
+    await rm(portableSource);
+    const updateResult = await syncWorkspace(workspacePath);
+
+    expect(updateResult.success).toBe(true);
+    expect(updateResult.deletedArtifacts).toBeUndefined();
+    expect((await readState()).files.copilot).toEqual([
+      '.github/agents/reviewer.agent.md',
+    ]);
+
+    await writeWorkspace([]);
+    const removalResult = await syncWorkspace(workspacePath);
+
+    expect(
+      existsSync(join(workspacePath, '.github/agents/reviewer.agent.md')),
+    ).toBe(false);
+    expect(removalResult.deletedArtifacts).toEqual([
+      { client: 'copilot', type: 'agent', name: 'reviewer' },
+    ]);
+  });
+
+  it('does not report an existing portable agent as deleted when dedupe replaces its path', async () => {
+    const pluginPath = join(workspacePath, 'plugin');
+    await writePluginAgent(
+      pluginPath,
+      'agents/reviewer.md',
+      'reviewer',
+      'Portable reviewer',
+    );
+    await writePluginAgent(
+      pluginPath,
+      '.github/agents/reviewer.agent.md',
+      'reviewer',
+      'GitHub reviewer',
+    );
+    await writeWorkspace([pluginPath]);
+    const previousState: SyncState = {
+      version: 1,
+      lastSync: new Date(0).toISOString(),
+      files: { copilot: ['.github/agents/reviewer.md'] },
+    };
+    await writeFile(
+      join(workspacePath, CONFIG_DIR, 'sync-state.json'),
+      JSON.stringify(previousState),
+    );
+
+    const result = await syncWorkspace(workspacePath);
+
+    expect(result.success).toBe(true);
+    expect(result.deletedArtifacts).toBeUndefined();
+  });
+
+  it('resolves VS Code agent paths from each plugin client set', async () => {
+    const copilotPlugin = join(workspacePath, 'copilot-plugin');
+    const vscodePlugin = join(workspacePath, 'vscode-plugin');
+    await mkdir(copilotPlugin, { recursive: true });
+    await writePluginAgent(
+      vscodePlugin,
+      'agents/reviewer.md',
+      'reviewer',
+      'Portable reviewer',
+    );
+    await writePluginAgent(
+      vscodePlugin,
+      '.github/agents/reviewer.agent.md',
+      'reviewer',
+      'GitHub reviewer',
+    );
+    await mkdir(join(workspacePath, CONFIG_DIR), { recursive: true });
+    await writeFile(
+      join(workspacePath, CONFIG_DIR, WORKSPACE_CONFIG_FILE),
+      [
+        'version: 2',
+        'repositories: []',
+        'plugins:',
+        `  - source: ${copilotPlugin}`,
+        '    clients: [copilot]',
+        `  - source: ${vscodePlugin}`,
+        '    clients: [vscode]',
+        'clients: []',
+        '',
+      ].join('\n'),
+    );
+
+    const result = await syncWorkspace(workspacePath);
+
+    expect(result.success).toBe(true);
+    expect(existsSync(join(workspacePath, '.github/agents/reviewer.md'))).toBe(
+      false,
+    );
+    expect(
+      existsSync(join(workspacePath, '.github/agents/reviewer.agent.md')),
+    ).toBe(false);
+  });
+
+  it('isolates agent discovery failures to the affected plugin', async () => {
+    const brokenPlugin = join(workspacePath, 'broken-plugin');
+    const healthyPlugin = join(workspacePath, 'healthy-plugin');
+    await mkdir(brokenPlugin, { recursive: true });
+    await writeFile(join(brokenPlugin, 'agents'), 'not a directory');
+    await writePluginAgent(
+      healthyPlugin,
+      'agents/healthy.md',
+      'healthy',
+      'Healthy portable agent',
+    );
+    await writeWorkspace([brokenPlugin, healthyPlugin]);
+
+    const result = await syncWorkspace(workspacePath);
+
+    expect(result.success).toBe(false);
+    expect(existsSync(join(workspacePath, '.github/agents/healthy.md'))).toBe(
+      true,
+    );
+    const brokenResult = result.pluginResults.find(
+      (plugin) => plugin.resolved === brokenPlugin,
+    );
+    expect(
+      brokenResult?.copyResults.some(
+        (copy) => copy.action === 'failed' && copy.source.endsWith('/agents'),
+      ),
+    ).toBe(true);
+  });
+
+  it('does not let a malformed GitHub agents entry block a healthy plugin', async () => {
+    const brokenPlugin = join(workspacePath, 'broken-plugin');
+    const healthyPlugin = join(workspacePath, 'healthy-plugin');
+    await mkdir(join(brokenPlugin, '.github'), { recursive: true });
+    await writeFile(
+      join(brokenPlugin, '.github', 'agents'),
+      'not a directory',
+    );
+    await writePluginAgent(
+      healthyPlugin,
+      'agents/healthy.md',
+      'healthy',
+      'Healthy portable agent',
+    );
+    await writeWorkspace([brokenPlugin, healthyPlugin]);
+
+    const result = await syncWorkspace(workspacePath);
+
+    expect(result.success).toBe(false);
+    expect(existsSync(join(workspacePath, '.github/agents/healthy.md'))).toBe(
+      true,
+    );
+    const brokenResult = result.pluginResults.find(
+      (plugin) => plugin.resolved === brokenPlugin,
+    );
+    expect(
+      brokenResult?.copyResults.some(
+        (copy) =>
+          copy.action === 'failed' && copy.source.endsWith('/.github/agents'),
+      ),
+    ).toBe(true);
+  });
+
+  it('uses first-configured-plugin ownership for agent filename conflicts', async () => {
+    const pluginA = join(workspacePath, 'plugin-a');
+    const pluginB = join(workspacePath, 'plugin-b');
+    await writePluginAgent(
+      pluginA,
+      'agents/shared.md',
+      'alpha',
+      'Plugin A portable agent',
+    );
+    await writePluginAgent(
+      pluginB,
+      'agents/shared.md',
+      'beta',
+      'Plugin B portable agent',
+    );
+    await writePluginAgent(
+      pluginB,
+      '.github/agents/beta.agent.md',
+      'beta',
+      'Plugin B GitHub agent',
+    );
+
+    await writeWorkspace([pluginA, pluginB]);
+    const firstResult = await syncWorkspace(workspacePath);
+
+    expect(
+      await readFile(join(workspacePath, '.github/agents/shared.md'), 'utf-8'),
+    ).toContain('Plugin A portable agent');
+    expect(
+      existsSync(join(workspacePath, '.github/agents/beta.agent.md')),
+    ).toBe(true);
+    expect(firstResult.messages).toBeUndefined();
+    expect(
+      firstResult.warnings?.some(
+        (warning) => warning.includes('plugin-b') && warning.includes('shared.md'),
+      ),
+    ).toBe(true);
+
+    await writeWorkspace([pluginB, pluginA]);
+    const reversedResult = await syncWorkspace(workspacePath);
+
+    expect(existsSync(join(workspacePath, '.github/agents/shared.md'))).toBe(
+      false,
+    );
+    expect(
+      await readFile(
+        join(workspacePath, '.github/agents/beta.agent.md'),
+        'utf-8',
+      ),
+    ).toContain('Plugin B GitHub agent');
+    expect(reversedResult.messages).toEqual([
+      "Deduped agent 'beta': removed .github/agents/shared.md (kept .github/agents/beta.agent.md)",
+    ]);
+    expect(
+      reversedResult.warnings?.some(
+        (warning) => warning.includes('plugin-a') && warning.includes('shared.md'),
+      ),
+    ).toBe(true);
+  });
+});

--- a/tests/unit/core/sync-deleted-artifacts.test.ts
+++ b/tests/unit/core/sync-deleted-artifacts.test.ts
@@ -76,6 +76,43 @@ describe('computeDeletedArtifacts', () => {
     expect(result).toEqual([{ client: 'copilot', type: 'agent', name: 'reviewer' }]);
   });
 
+  it('normalizes the GitHub .agent.md suffix in deleted agent names', () => {
+    const previousState = makeState({
+      copilot: ['.github/agents/reviewer.agent.md'],
+    });
+
+    expect(
+      computeDeletedArtifacts(
+        previousState,
+        { copilot: [] },
+        ['copilot'],
+        CLIENT_MAPPINGS,
+      ),
+    ).toEqual([{ client: 'copilot', type: 'agent', name: 'reviewer' }]);
+  });
+
+  it('treats a successful dedupe replacement as the same agent representation', () => {
+    const previousState = makeState({
+      copilot: ['.github/agents/reviewer.md'],
+    });
+    const replacement = {
+      name: 'reviewer',
+      removedPath: '.github/agents/reviewer.md',
+      keptPath: '.github/agents/reviewer.agent.md',
+    };
+
+    expect(
+      computeDeletedArtifacts(
+        previousState,
+        { copilot: ['.github/agents/reviewer.agent.md'] },
+        ['copilot'],
+        CLIENT_MAPPINGS,
+        undefined,
+        [replacement],
+      ),
+    ).toEqual([]);
+  });
+
   it('only reports artifacts not re-provided by new sync', () => {
     const previousState = makeState({
       claude: [


### PR DESCRIPTION
## Source

Reported here (internal, cited for reference only): https://teams.microsoft.com/l/message/19:d29d75b3931b4302b9bd9d968d55adcf@thread.skype/1787648455643?tenantId=8b493985-e1b4-4b95-ade6-98acafdbdb01&groupId=188ba793-8136-4b10-b984-10097d7bb40c&parentMessageId=1787648455643&teamName=Development%20Customs%20Team&channelName=Customs%20Specifications%20(Specs-as-Code)&createdTime=1787648455643

## Problem

A synced workspace's `.github/agents/` directory can contain two files for the same logical agent, for example `cw-reviewer.md` and `cw-reviewer.agent.md`, both declaring `name: cw-reviewer`.

This happens when a plugin ships both:

- a portable `agents/<name>.md` definition; and
- a GitHub-format `.github/agents/<name>.agent.md` definition.

For Copilot these routes converge on `.github/agents/`. VS Code versions that discover both Markdown files show the logical agent twice. The GitHub-format `.agent.md` file was also not tracked individually because `.github` copying previously returned one aggregate result.

## Fix

- Build one immutable agent-output plan before concurrent plugin copies.
- Resolve every plugin's actual client mappings independently; Claude receives only its portable `.md`, while Copilot/compatible VS Code routes can receive both formats.
- Use configuration order for cross-plugin conflicts: the first configured valid provider owns a destination/logical name, and later providers are skipped with a warning.
- Copy top-level GitHub agent definitions individually while preserving nested files and companion assets through the aggregate `.github` copy.
- Dedupe only a successful same-plugin pair consisting of a plain portable `.md` and a GitHub-route `.agent.md` with the same frontmatter `name` in the same physical directory.
- Preserve and track the portable definition when the preferred GitHub-format copy fails.
- Track GitHub-format-only agents individually so later plugin removal purges them.
- Treat `.md` to `.agent.md` replacement as one logical agent during deletion reporting; later removal reports `reviewer`, not `reviewer.agent`.
- Preserve dry-run parity without reading or modifying destination files.

## Scope

This dedupes representations within the same Copilot/VS Code agent directory. It does not collapse definitions across `.claude/agents/` and `.github/agents/`; those are distinct client destinations.

## Verification

Automated:

- `bun run build`
- `bun run typecheck`
- `bun run lint`
- Focused agent regression suite: 57 passed, 0 failed
- Full suite: `bun test --timeout 10000` — 1527 passed, 6 skipped, 0 failed

Built-CLI smoke test:

```bash
HOME=/tmp/allagents-pr471-smoke/home \
  bun dist/index.js workspace sync --verbose

HOME=/tmp/allagents-pr471-smoke/home \
  bun dist/index.js workspace sync --dry-run --verbose
```

The fixture used one local plugin with `agents/reviewer.md` and `.github/agents/reviewer.agent.md`, targeting Claude and Copilot. Verified:

- `.claude/agents/reviewer.md` remains present and tracked.
- `.github/agents/reviewer.md` is removed after successful dedupe.
- `.github/agents/reviewer.agent.md` remains present and tracked.
- CLI reports one Claude agent and one Copilot agent.
- Fresh dry-run reports the same planned dedupe and writes neither files nor sync state.
- After the plugin drops its portable source, the GitHub-format file remains tracked.
- After plugin removal, the GitHub-format file is purged and reported as `Deleted: agent 'reviewer'`.
